### PR TITLE
Add a stub change-request API endpoint

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -1,10 +1,11 @@
 from django.urls import path
 
-from .views import CompanyUpdatesApiView, DNBCompanySearchApiView
+from .views import ChangeRequestApiView, CompanyUpdatesApiView, DNBCompanySearchApiView
 
 app_name = 'api'
 
 urlpatterns = [
     path('companies/', CompanyUpdatesApiView.as_view(), name='company-updates'),
     path('companies/search/', DNBCompanySearchApiView.as_view(), name='company-search'),
+    path('change-request/', ChangeRequestApiView.as_view(), name='change-request'),
 ]

--- a/api/views.py
+++ b/api/views.py
@@ -1,5 +1,7 @@
+import uuid
 import datetime
 
+from django.utils.timezone import now
 from rest_framework import generics
 from requests.exceptions import HTTPError
 from rest_framework.exceptions import ParseError
@@ -8,12 +10,14 @@ from rest_framework.views import APIView
 
 from .serialisers import CompanySearchInputSerialiser
 from company.models import Company
-from company.serialisers import CompanySerialiser
+from company.serialisers import ChangeRequestSerialiser, CompanySerialiser
 from dnb_direct_plus.api import company_list_search
 
 
 class DNBCompanySearchApiView(APIView):
-    """An API view that proxies requests to Dun & Bradstreet's CompanyList search."""
+    """
+    An API view that proxies requests to Dun & Bradstreet's CompanyList search.
+    """
 
     def post(self, request):
         serialiser = CompanySearchInputSerialiser(data=request.data)
@@ -44,3 +48,23 @@ class CompanyUpdatesApiView(generics.ListAPIView):
             queryset = queryset.filter(last_updated__gte=last_updated)
 
         return queryset
+
+
+class ChangeRequestApiView(APIView):
+    """
+    Endpoint to save a new ChangeRequest record on POST.
+    """
+
+    def post(self, request):
+        serialiser = ChangeRequestSerialiser(data=request.data)
+        serialiser.is_valid(raise_exception=True)
+
+        # TODO: Once we have a ChangeRequest model, this view should save a new
+        # change request and respond with a serialised version of it. For now
+        # we are stubbing the response out
+        return Response({
+            'id': uuid.uuid4(),
+            **serialiser.data,
+            'status': 'pending',
+            'created_on': now().isoformat(),
+        })

--- a/company/serialisers.py
+++ b/company/serialisers.py
@@ -80,3 +80,55 @@ class CompanySerialiser(serializers.ModelSerializer):
             'primary_industry_codes',
             'industry_codes',
         ]
+
+
+class ChangeRequestChangesSerialiser(CompanySerialiser):
+    """
+    Serialised representation of company field changes that can be requested.
+    """
+
+    class Meta:
+        model = Company
+        fields = [
+            'primary_name',
+            'trading_names',
+            'domain',
+            'address_line_1',
+            'address_line_2',
+            'address_town',
+            'address_county',
+            'address_country',
+            'address_postcode',
+            'registered_address_line_1',
+            'registered_address_line_2',
+            'registered_address_town',
+            'registered_address_county',
+            'registered_address_country',
+            'registered_address_postcode',
+            'employee_number',
+            'annual_sales',
+            'annual_sales_currency',
+        ]
+        extra_kwargs = {
+            'primary_name': {
+                'required': False,
+            },
+            'annual_sales': {
+                'required': False,
+                'allow_null': False,
+            },
+            'employee_number': {
+                'required': False,
+                'allow_null': False,
+            },
+        }
+
+
+# TODO: Replace this with a ModelSerializer for the ChangeRequest model when we
+# add it
+class ChangeRequestSerialiser(serializers.Serializer):
+    """
+    Serialised representation of a ChangeRequest.
+    """
+    duns_number = serializers.CharField(max_length=9, min_length=9)
+    changes = ChangeRequestChangesSerialiser()

--- a/company/serialisers.py
+++ b/company/serialisers.py
@@ -1,6 +1,12 @@
 from rest_framework import serializers
 
-from company.models import Company, IndustryCode, PrimaryIndustryCode, RegistrationNumber
+from company.models import (
+    Company,
+    Country,
+    IndustryCode,
+    PrimaryIndustryCode,
+    RegistrationNumber,
+)
 
 
 class RegistrationNumberSerialiser(serializers.ModelSerializer):
@@ -86,6 +92,19 @@ class ChangeRequestChangesSerialiser(CompanySerialiser):
     """
     Serialised representation of company field changes that can be requested.
     """
+    address_country = serializers.SlugRelatedField(
+        many=False,
+        slug_field='iso_alpha2',
+        queryset=Country.objects.all(),
+        required=False,
+    )
+
+    registered_address_country = serializers.SlugRelatedField(
+        many=False,
+        slug_field='iso_alpha2',
+        queryset=Country.objects.all(),
+        required=False,
+    )
 
     class Meta:
         model = Company


### PR DESCRIPTION
This PR adds a stub API endpoint for recording company change requests.  It implements the following contact: https://trello.com/c/eW5WlqDg/770-agree-api-and-dnb-service-contract-for-automatic-company-change-requests

The idea for this is that Data Hub will use this endpoint when users request changes to a company record.  The aspiration will be to also add a ChangeRequest model which will record these requests on dnb-service - and eventually batch change requests up and send them on to D&B via email.  This will follow in subsequent PRs according to the loose overall plan outlined here: https://docs.google.com/document/d/1TMZTrWfvSQLNSIPQsEO1zsYFA_bk41lO3NAZX3aUMLg/edit