### PR TITLE
Add generate_change_request_csv utility

### DIFF
--- a/company/tests/factories.py
+++ b/company/tests/factories.py
@@ -31,7 +31,7 @@ class RegistrationNumberFactory(factory.django.DjangoModelFactory):
 class IndustryCodeFactory(factory.django.DjangoModelFactory):
 
     code = factory.Sequence(lambda n: str(n).zfill(4))
-    priority = factory.Sequence(lambda n: n+1)
+    priority = factory.Sequence(lambda n: n + 1)
 
     class Meta:
         model = 'company.IndustryCode'
@@ -43,3 +43,11 @@ class PrimaryIndustryCodeFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = 'company.PrimaryIndustryCode'
+
+
+class ChangeRequestFactory(factory.django.DjangoModelFactory):
+
+    duns_number = factory.Sequence(lambda n: str(n).zfill(9))
+
+    class Meta:
+        model = 'company.ChangeRequest'

--- a/company/tests/test_utils.py
+++ b/company/tests/test_utils.py
@@ -51,8 +51,8 @@ class TestGenerateChangeRequestCSV:
                 ),
             ],
         ]
-        csv_content = generate_change_request_csv([partial_change_request, full_change_request])
-        reader = csv.reader(io.StringIO(csv_content.decode('utf-8')), dialect='excel', delimiter=',')
+        csv_file = generate_change_request_csv([partial_change_request, full_change_request])
+        reader = csv.reader(csv_file, dialect='excel', delimiter=',')
         for row, expected_row in zip(reader, expected_rows):
             assert row == expected_row
 

--- a/company/tests/test_utils.py
+++ b/company/tests/test_utils.py
@@ -1,0 +1,69 @@
+import csv
+import io
+
+import pytest
+
+from company.utils import generate_change_request_csv, IncompleteAddressException
+from company.tests.factories import ChangeRequestFactory
+
+
+@pytest.mark.django_db
+class TestGenerateChangeRequestCSV:
+
+    def test_csv_generated_correctly(self):
+        """
+        Test that the csv is generated as expected for both a partial and a full change request.
+        """
+        partial_change_request = ChangeRequestFactory(changes={'primary_name': 'Foo'})
+        full_change_request = ChangeRequestFactory(changes={
+            'primary_name': 'Bar',
+            'trading_names': ['Bar inc', 'Bar LTD'],
+            'domain': 'example.net',
+            'address_line_1': '123 Fake Lane',
+            'address_line_2': 'Somewhere',
+            'address_town': 'Southampton',
+            'address_county': 'Hampshire',
+            'address_postcode': 'SO31 9TB',
+            'address_country': 'GB',
+            'registered_address_line_1': '123 Fake Street',
+            'registered_address_line_2': 'Some Place',
+            'registered_address_town': 'London',
+            'registered_address_county': 'Greater London',
+            'registered_address_postcode': 'W1 9TB',
+            'registered_address_country': 'GB',
+            'employee_number': 190,
+            'annual_sales': 1050.0,
+            'annual_sales_currency': 'GBP',
+        })
+        expected_rows = [
+            [partial_change_request.duns_number, 'Business Name: Foo'],
+            [
+                full_change_request.duns_number,
+                (
+                    'Business Name: Bar; '
+                    "Trading Name(s): ['Bar inc', 'Bar LTD']; "
+                    'Website Domain: example.net; '
+                    'Address: 123 Fake Lane, Somewhere, Southampton, Hampshire, SO31 9TB, GB; '
+                    'Registered Address: 123 Fake Street, Some Place, London, Greater London, W1 9TB, GB; '
+                    'Employee Number: 190; '
+                    'Annual Sales: 1050.0; '
+                    'Annual Sales Currency: GBP'
+                ),
+            ],
+        ]
+        csv_content = generate_change_request_csv([partial_change_request, full_change_request])
+        reader = csv.reader(io.StringIO(csv_content.decode('utf-8')), dialect='excel', delimiter=',')
+        for row, expected_row in zip(reader, expected_rows):
+            assert row == expected_row
+
+    def test_exception_raised_for_empty_change_requests(self):
+        """
+        Test that an IndexError is raised when generate_change_request_csv is called with an empty list.
+        """
+        with pytest.raises(IndexError):
+            generate_change_request_csv([])
+
+    def test_exception_raised_for_partial_address(self):
+        incomplete_change_request = ChangeRequestFactory(changes={'address_line_1': 'Foo'})
+        with pytest.raises(IncompleteAddressException):
+            generate_change_request_csv([incomplete_change_request])

--- a/company/tests/test_utils.py
+++ b/company/tests/test_utils.py
@@ -1,5 +1,4 @@
 import csv
-import io
 
 import pytest
 
@@ -36,6 +35,7 @@ class TestGenerateChangeRequestCSV:
             'annual_sales_currency': 'GBP',
         })
         expected_rows = [
+            ['duns_number', 'changes'],
             [partial_change_request.duns_number, 'Business Name: Foo'],
             [
                 full_change_request.duns_number,
@@ -62,8 +62,3 @@ class TestGenerateChangeRequestCSV:
         """
         with pytest.raises(IndexError):
             generate_change_request_csv([])
-
-    def test_exception_raised_for_partial_address(self):
-        incomplete_change_request = ChangeRequestFactory(changes={'address_line_1': 'Foo'})
-        with pytest.raises(IncompleteAddressException):
-            generate_change_request_csv([incomplete_change_request])

--- a/company/utils.py
+++ b/company/utils.py
@@ -54,7 +54,7 @@ def _get_change_request_row(change_request):
 def generate_change_request_csv(change_requests):
     """
     Given an iterable of ChangeRequest records, generate a CSV of changes which is readable by D&B
-    support staff. The returned CSV content is a bytes object, ready for sending by email.
+    support staff. The returned CSV content is file object, ready for sending by email.
     """
     if not change_requests:
         raise IndexError("Cannot generate a change request CSV for an empty list of change requests.")
@@ -62,5 +62,4 @@ def generate_change_request_csv(change_requests):
     writer = csv.writer(writer_file, dialect='excel', delimiter=',')
     for change_request in change_requests:
         writer.writerow(_get_change_request_row(change_request))
-    content = writer_file.getvalue().encode('utf-8')
-    return content
+    return writer_file

--- a/company/utils.py
+++ b/company/utils.py
@@ -1,0 +1,66 @@
+import io
+import csv
+from copy import deepcopy
+
+
+FIELD_LABELS = {
+    'primary_name': 'Business Name',
+    'trading_names': 'Trading Name(s)',
+    'domain': 'Website Domain',
+    'address': 'Address',
+    'registered_address': 'Registered Address',
+    'employee_number': 'Employee Number',
+    'annual_sales': 'Annual Sales',
+    'annual_sales_currency': 'Annual Sales Currency',
+}
+
+
+class IncompleteAddressException(Exception):
+    """
+    An error to explain that some address fields were missing for a particular ChangeRequest
+    record.  ChangeRequests for addresses must be all or nothing.
+    """
+
+
+def _flatten_address(prefix, changes):
+    try:
+        address_components = [
+            changes.pop(f'{prefix}_{field}')
+            for field in ['line_1', 'line_2', 'town', 'county', 'postcode', 'country']
+        ]
+    except KeyError:
+        raise IncompleteAddressException(
+            f'Some {prefix} field(s) were missing. ChangeRequests for addresses must be all or nothing.'
+        )
+    changes[prefix] = ', '.join(address_components)
+    return changes
+
+
+def _get_change_request_row(change_request):
+    row = [change_request.duns_number]
+    changes = deepcopy(change_request.changes)
+    if 'address_line_1' in changes:
+        changes = _flatten_address('address', changes)
+    if 'registered_address_line_1' in changes:
+        changes = _flatten_address('registered_address', changes)
+    readable_changes = {
+        field_label: changes[field_name] for field_name, field_label in FIELD_LABELS.items() if field_name in changes
+    }
+    flat_readable_changes = [f'{key}: {value}' for key, value in readable_changes.items()]
+    row.append('; '.join(flat_readable_changes))
+    return row
+
+
+def generate_change_request_csv(change_requests):
+    """
+    Given an iterable of ChangeRequest records, generate a CSV of changes which is readable by D&B
+    support staff. The returned CSV content is a bytes object, ready for sending by email.
+    """
+    if not change_requests:
+        raise IndexError("Cannot generate a change request CSV for an empty list of change requests.")
+    writer_file = io.StringIO()
+    writer = csv.writer(writer_file, dialect='excel', delimiter=',')
+    for change_request in change_requests:
+        writer.writerow(_get_change_request_row(change_request))
+    content = writer_file.getvalue().encode('utf-8')
+    return content

--- a/company/utils.py
+++ b/company/utils.py
@@ -2,6 +2,8 @@ import io
 import csv
 from copy import deepcopy
 
+from company.constants import ADDRESS_FIELDS
+
 
 FIELD_LABELS = {
     'primary_name': 'Business Name',
@@ -22,44 +24,43 @@ class IncompleteAddressException(Exception):
     """
 
 
-def _flatten_address(prefix, changes):
-    try:
-        address_components = [
-            changes.pop(f'{prefix}_{field}')
-            for field in ['line_1', 'line_2', 'town', 'county', 'postcode', 'country']
-        ]
-    except KeyError:
-        raise IncompleteAddressException(
-            f'Some {prefix} field(s) were missing. ChangeRequests for addresses must be all or nothing.'
-        )
+def _get_address_string(prefix, changes):
+    address_components = [changes.pop(f'{prefix}_{field}') for field in ADDRESS_FIELDS]
     changes[prefix] = ', '.join(address_components)
     return changes
 
 
 def _get_change_request_row(change_request):
-    row = [change_request.duns_number]
     changes = deepcopy(change_request.changes)
     if 'address_line_1' in changes:
-        changes = _flatten_address('address', changes)
+        changes = _get_address_string('address', changes)
     if 'registered_address_line_1' in changes:
-        changes = _flatten_address('registered_address', changes)
+        changes = _get_address_string('registered_address', changes)
     readable_changes = {
         field_label: changes[field_name] for field_name, field_label in FIELD_LABELS.items() if field_name in changes
     }
     flat_readable_changes = [f'{key}: {value}' for key, value in readable_changes.items()]
-    row.append('; '.join(flat_readable_changes))
-    return row
+    return {
+        'duns_number': change_request.duns_number,
+        'changes': flat_readable_changes,
+    }
 
 
 def generate_change_request_csv(change_requests):
     """
     Given an iterable of ChangeRequest records, generate a CSV of changes which is readable by D&B
     support staff. The returned CSV content is file object, ready for sending by email.
+
+    The CSV file is in the following example format:
+    "duns_number","changes"
+    "123456789","Address: 123 Fake Street, Burgess Hill, RH15 0TN, Sussex, GB; Business Name: BSmitty LTD;"
     """
     if not change_requests:
         raise IndexError("Cannot generate a change request CSV for an empty list of change requests.")
     writer_file = io.StringIO()
-    writer = csv.writer(writer_file, dialect='excel', delimiter=',')
+    field_names = ['duns_number', 'changes']
+    writer = csv.DictWriter(writer_file, fieldnames=field_names, dialect='excel', delimiter=',')
+    writer.writeheader()
     for change_request in change_requests:
         writer.writerow(_get_change_request_row(change_request))
     return writer_file


### PR DESCRIPTION
This PR adds a utility function `company.utils.generate_change_request_csv`.  The function takes an iterable of ChangeRequest records and generates a human-readable CSV of changes according to the sample CSV format agreed with Michael here: https://docs.google.com/spreadsheets/d/1IVCf_W6qAVjQr5bxc7U1U0bRw23YpHC92HUQ3mZfxgk/edit#gid=0

The aspiration is for this function to be used to generate a CSV attachment for an email to send on to Dun and Bradstreet.  Right now, the function returns a bytes object since looking at the amazon-ses documentation, it looks like this is the best format for attaching to an email.

