### PR TITLE
Investigation request serialiser

### DIFF
--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -373,18 +373,6 @@ class TestInvestigationApiView:
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
-    @pytest.mark.xfail
-    def test_not_implemented(self, auth_client):
-        """
-        Test that authenticated request return 501 - Not Implemented.
-        """
-        response = auth_client.post(
-            reverse('api:investigation'),
-            {},
-        )
-
-        assert response.status_code == status.HTTP_501_NOT_IMPLEMENTED
-
     @freeze_time('2019-11-25 12:00:01 UTC')
     @pytest.mark.parametrize(
         'request_data',

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -373,6 +373,7 @@ class TestInvestigationApiView:
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
+    @pytest.mark.xfail
     def test_not_implemented(self, auth_client):
         """
         Test that authenticated request return 501 - Not Implemented.
@@ -383,3 +384,221 @@ class TestInvestigationApiView:
         )
 
         assert response.status_code == status.HTTP_501_NOT_IMPLEMENTED
+
+    @freeze_time('2019-11-25 12:00:01 UTC')
+    @pytest.mark.parametrize(
+        'request_data',
+        (
+            {
+                'company_details': {
+                    'primary_name': 'Foo Bar',
+                    'domain': 'example.com',
+                    'telephone_number': '12345678',
+                    'address_line_1': '123 Fake Street',
+                    'address_line_2': 'Foo',
+                    'address_town': 'London',
+                    'address_county': 'Greater London',
+                    'address_country': 'GB',
+                    'address_postcode': 'W1 0TN',
+                },
+            },
+            # No domain
+            {
+                'company_details': {
+                    'primary_name': 'Foo Bar',
+                    'telephone_number': '12345678',
+                    'address_line_1': '123 Fake Street',
+                    'address_line_2': 'Foo',
+                    'address_town': 'London',
+                    'address_county': 'Greater London',
+                    'address_country': 'GB',
+                    'address_postcode': 'W1 0TN',
+                },
+            },
+            # No telephone_number
+            {
+                'company_details': {
+                    'primary_name': 'Foo Bar',
+                    'domain': 'example.com',
+                    'address_line_1': '123 Fake Street',
+                    'address_line_2': 'Foo',
+                    'address_town': 'London',
+                    'address_county': 'Greater London',
+                    'address_country': 'GB',
+                    'address_postcode': 'W1 0TN',
+                },
+            },
+            # No non-required address fields
+            {
+                'company_details': {
+                    'primary_name': 'Foo Bar',
+                    'domain': 'example.com',
+                    'telephone_number': '12345678',
+                    'address_line_1': '123 Fake Street',
+                    'address_town': 'London',
+                    'address_country': 'GB',
+                },
+            },
+        )
+    )
+    def test_valid(self, auth_client, request_data):
+        """
+        Test that a valid investigation payload returns the expected
+        response.
+        """
+        response = auth_client.post(
+            reverse('api:investigation'),
+            request_data,
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        response_data = response.json()
+        response_data.pop('id')
+        assert response_data == {
+            'status': 'pending',
+            'created_on': '2019-11-25T12:00:01Z',
+            'submitted_on': None,
+            **request_data,
+        }
+
+    @pytest.mark.parametrize(
+        'request_data, expected_response',
+        (
+            # Missing company_details
+            (
+                {},
+                {
+                    'company_details': ['This field is required.'],
+                },
+            ),
+            # Missing primary_name
+            (
+                {
+                    'company_details': {
+                        'domain': 'example.com',
+                        'telephone_number': '12345678',
+                        'address_line_1': '123 Fake Street',
+                        'address_line_2': 'Foo',
+                        'address_town': 'London',
+                        'address_county': 'Greater London',
+                        'address_country': 'GB',
+                        'address_postcode': 'W1 0TN',
+                    },
+                },
+                {
+                    'company_details': {
+                        'primary_name': ['This field is required.'],
+                    },
+                },
+            ),
+            # Missing domain & telephone_number
+            (
+                {
+                    'company_details': {
+                        'primary_name': 'Foo Bar',
+                        'address_line_1': '123 Fake Street',
+                        'address_line_2': 'Foo',
+                        'address_town': 'London',
+                        'address_county': 'Greater London',
+                        'address_country': 'GB',
+                        'address_postcode': 'W1 0TN',
+                    },
+                },
+                {
+                    'company_details': {
+                        'non_field_errors': [
+                            'Either domain or telephone_number must be '
+                            'provided for D&B investigation.'
+                        ],
+                    },
+                },
+            ),
+            # Missing address_line_1
+            (
+                {
+                    'company_details': {
+                        'primary_name': 'Foo Bar',
+                        'domain': 'example.com',
+                        'address_line_2': 'Foo',
+                        'address_town': 'London',
+                        'address_county': 'Greater London',
+                        'address_country': 'GB',
+                        'address_postcode': 'W1 0TN',
+                    },
+                },
+                {
+                    'company_details': {
+                        'address_line_1': ['This field is required.'],
+                    },
+                },
+            ),
+            # Missing address_town
+            (
+                {
+                    'company_details': {
+                        'primary_name': 'Foo Bar',
+                        'domain': 'example.com',
+                        'address_line_1': '123 Fake Street',
+                        'address_line_2': 'Foo',
+                        'address_county': 'Greater London',
+                        'address_country': 'GB',
+                        'address_postcode': 'W1 0TN',
+                    },
+                },
+                {
+                    'company_details': {
+                        'address_town': ['This field is required.'],
+                    },
+                },
+            ),
+            # Missing address_country
+            (
+                {
+                    'company_details': {
+                        'primary_name': 'Foo Bar',
+                        'domain': 'example.com',
+                        'address_line_1': '123 Fake Street',
+                        'address_line_2': 'Foo',
+                        'address_town': 'London',
+                        'address_county': 'Greater London',
+                        'address_postcode': 'W1 0TN',
+                    },
+                },
+                {
+                    'company_details': {
+                        'address_country': ['This field is required.'],
+                    },
+                },
+            ),
+            # Invalid address_country
+            (
+                {
+                    'company_details': {
+                        'primary_name': 'Foo Bar',
+                        'domain': 'example.com',
+                        'address_line_1': '123 Fake Street',
+                        'address_line_2': 'Foo',
+                        'address_town': 'London',
+                        'address_county': 'Greater London',
+                        'address_country': 'XX',
+                        'address_postcode': 'W1 0TN',
+                    },
+                },
+                {
+                    'company_details': {
+                        'address_country': ['This is not a valid ISO Alpha2 country code.'],
+                    },
+                },
+            ),
+        )
+    )
+    def test_invalid(self, auth_client, request_data, expected_response):
+        """
+        Test that an invalid investigation payload returns a 400 response and
+        a helpful error message.
+        """
+        response = auth_client.post(
+            reverse('api:investigation'),
+            request_data,
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == expected_response

--- a/api/views.py
+++ b/api/views.py
@@ -9,8 +9,8 @@ from rest_framework import status
 from rest_framework.views import APIView
 
 from .serialisers import CompanySearchInputSerialiser
-from company.models import ChangeRequest, Company
-from company.serialisers import ChangeRequestSerialiser, CompanySerialiser
+from company.models import ChangeRequest, Company, InvestigationRequest
+from company.serialisers import ChangeRequestSerialiser, CompanySerialiser, InvestigationRequestSerializer
 from dnb_direct_plus.api import company_list_search
 
 
@@ -65,8 +65,5 @@ class InvestigationAPIView(CreateAPIView):
     At the moment, this will return 501 - Not Implemented.
     """
 
-    def post(self, request, *args, **kwargs):
-        """
-        Returns a 501 - Not Implemented.
-        """
-        return Response(status=status.HTTP_501_NOT_IMPLEMENTED)
+    queryset = InvestigationRequest.objects.all()
+    serializer_class = InvestigationRequestSerializer


### PR DESCRIPTION
This adds an `InvestigationRequestSerializer`, hooks it up with the `InvestigationAPIView` & adds a bunch of tests for valid and invalid payloads.

I would recommend to review per commit.