### PR TITLE
Add investigation-request template ID

### DIFF
--- a/core/notify.py
+++ b/core/notify.py
@@ -9,7 +9,8 @@ notifications_client = NotificationsAPIClient(settings.GOVUK_NOTIFICATIONS_API_K
 
 
 TEMPLATE_IDS = {
-    'change-request': 'd3fb8a4b-61d5-44f3-b9e9-8fa5a4894ffb',
+    'change-request': '54d1cca9-5aea-4dcd-8d70-72c2fcc80f11',
+    'investigation-request': 'd895cace-d746-4888-b08e-a8758ad7ba8b',
 }
 
 


### PR DESCRIPTION
This also changes the `change-request` template ID.

Templates can be found [here](https://www.notifications.service.gov.uk/services/292ea539-1d0c-42f2-b1e8-c7ae1f2709f2/templates).