### PR TITLE
ChangeRequest/InvestigationRequest admin pages

### DIFF
--- a/company/admin.py
+++ b/company/admin.py
@@ -1,6 +1,14 @@
 from django.contrib import admin
 
-from .models import Company, Country, IndustryCode, PrimaryIndustryCode, RegistrationNumber
+from .models import (
+    ChangeRequest,
+    Company,
+    Country,
+    IndustryCode,
+    InvestigationRequest,
+    PrimaryIndustryCode,
+    RegistrationNumber,
+)
 
 
 class RegistrationNumberInline(admin.TabularInline):
@@ -31,3 +39,13 @@ class CompanyAdmin(admin.ModelAdmin):
 @admin.register(Country)
 class CountryAdmin(admin.ModelAdmin):
     list_display = ('name', 'iso_alpha2', 'iso_alpha3', 'iso_numeric')
+
+
+@admin.register(ChangeRequest)
+class ChangeRequestAdmin(admin.ModelAdmin):
+    list_display = ('duns_number', 'status', 'created_on')
+
+
+@admin.register(InvestigationRequest)
+class InvestigationRequestAdmin(admin.ModelAdmin):
+    list_display = ('id', 'status', 'created_on')

--- a/config/settings.py
+++ b/config/settings.py
@@ -149,6 +149,8 @@ LOGIN_REDIRECT_URL = 'admin:index'
 
 AUTH_USER_MODEL = 'user.User'
 
+ENABLE_STAFF_SSO = env.bool('ENABLE_STAFF_SSO', True)
+
 # IP restriction
 
 IP_RESTRICT = env.bool('IP_RESTRICT')

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,11 +1,19 @@
+from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path
 
 from core.admin_views import admin_login_view
 
+auth_urls = []
+
+if settings.ENABLE_STAFF_SSO:
+    auth_urls = [
+        path('auth/', include('authbroker_client.urls', namespace='authbroker')),
+        path('admin/login/', admin_login_view),
+    ]
+
 urlpatterns = [
-    path('auth/', include('authbroker_client.urls', namespace='authbroker')),
-    path('admin/login/', admin_login_view),
+    *auth_urls,
     path('admin/', admin.site.urls),
     path('api/', include('api.urls', namespace='api')),
     path('healthcheck/', include('health_check.urls', namespace='healthcheck')),


### PR DESCRIPTION
This PR adds some basic admin pages for ChangeRequest/InvestigationRequest models.

I've also added in an `ENABLE_STAFF_SSO` setting/environment variable which is True by default.  It governs whether or not to use the authbroker machinery for authenticating users.  This was necessary to make development easily on my local copy - hopefully it can help other devs working on admin pages too.