### PR TITLE
Add task to email investigation requests daily

### DIFF
--- a/company/tests/conftest.py
+++ b/company/tests/conftest.py
@@ -1,0 +1,19 @@
+import io
+
+import pytest
+
+from company.utils import generate_investigation_request_csv
+
+
+@pytest.fixture()
+def get_csv_bytes():
+    """
+    Returns bytes of CSV given InvestigationRequest objects.
+    """
+    def _get_csv_bytes(investigation):
+        return io.BytesIO(
+            generate_investigation_request_csv(
+                investigation,
+            ).getvalue().encode('utf-8')
+        ).getvalue()
+    return _get_csv_bytes

--- a/company/tests/test_utils.py
+++ b/company/tests/test_utils.py
@@ -218,7 +218,7 @@ class TestSendInvestigationRequestBatch:
         ]
     )
     @mock.patch('company.utils.notify_by_email')
-    def test_success(self, mock_notify):
+    def test_success(self, mock_notify, get_csv_bytes):
         """
         Given a list of `InvestigationRequest` objects and a `batch_identifier`:
 
@@ -243,12 +243,7 @@ class TestSendInvestigationRequestBatch:
             [investigation_request],
             'Batch 1',
         )
-
-        csv_bytes = io.BytesIO(
-            generate_investigation_request_csv(
-                [investigation_request],
-            ).getvalue().encode('utf-8')
-        ).getvalue()
+        csv_bytes = get_csv_bytes([investigation_request])
 
         mock_notify.assert_called_with(
             'bar@example.net',

--- a/company/utils.py
+++ b/company/utils.py
@@ -151,5 +151,6 @@ def send_investigation_request_batch(investigation_requests, batch_identifier):
             context
         )
 
+    submitted_on = now()
     for investigation_request in investigation_requests:
-        investigation_request.mark_as_submitted()
+        investigation_request.mark_as_submitted(submitted_on=submitted_on)

--- a/config/settings.py
+++ b/config/settings.py
@@ -244,3 +244,9 @@ if env.bool('ENABLE_CHANGE_REQUESTS_SUBMISSION', False):
         'task': 'company.tasks.send_pending_change_requests',
         'schedule': crontab(minute=0, hour=1,),
     }
+
+if env.bool('ENABLE_INVESTIGATION_REQUESTS_SUBMISSION', False):
+    CELERY_BEAT_SCHEDULE['investigation_requests_submission'] = {
+        'task': 'company.tasks.send_pending_investigation_requests',
+        'schedule': crontab(minute=0, hour=2,),
+    }


### PR DESCRIPTION
This adds a task that runs nightly and sends an email containing pending `InvestigationRequest` to the given recipients.