### PR TITLE
Bugfix/investgations email missing company name

### DIFF
--- a/company/tests/test_utils.py
+++ b/company/tests/test_utils.py
@@ -177,24 +177,24 @@ class TestGenerateInvestigationRequestCSV:
                     'address_country': 'GB',
                     'address_postcode': 'ABC DEF',
                 },
-                (
-                    (
+                [
+                    [
                         'ID',
                         'Name',
                         'Address',
                         'Domain',
                         'Telephone Number',
                         'DUNS Number',
-                    ),
-                    (
+                    ],
+                    [
                         mock.ANY,
                         'Foo',
                         'Bar, Buz, London, London, ABC DEF, GB',
                         'foo.com',
                         '(+44) 123 45678',
                         '',
-                    ),
-                ),
+                    ],
+                ],
             ),
         ),
     )
@@ -205,7 +205,7 @@ class TestGenerateInvestigationRequestCSV:
         investigation_request = InvestigationRequest(company_details=company_details)
         content = generate_investigation_request_csv([investigation_request])
         reader = csv.reader(content, dialect='excel', delimiter=',')
-        [row for row in reader] == expected_output
+        assert [row for row in reader] == expected_output
 
 
 class TestSendInvestigationRequestBatch:

--- a/company/utils.py
+++ b/company/utils.py
@@ -88,8 +88,8 @@ def _get_investigation_request_row(investigation_request):
     company_details = investigation_request.company_details
     return {
         'ID': str(investigation_request.id),
-        'Name': company_details.get('name'),
-        'Address': ','.join(
+        'Name': company_details.get('primary_name'),
+        'Address': ', '.join(
             [
                 company_details.get(f'address_{address_field}', '')
                 for address_field in ADDRESS_FIELDS
@@ -129,6 +129,7 @@ def generate_investigation_request_csv(investigation_requests):
             _get_investigation_request_row(investigation_request)
         )
 
+    csv_file.seek(0)
     return csv_file
 
 


### PR DESCRIPTION
This fixes an issue of missing company name in the investigations email. Turns out there was a missing `assert` in the test that should/could have exposed this 😄 