### PR TITLE
Log total companies updated

### DIFF
--- a/dnb_direct_plus/management/commands/process_monitoring_data.py
+++ b/dnb_direct_plus/management/commands/process_monitoring_data.py
@@ -33,6 +33,9 @@ class Command(BaseCommand):
             .copy_from(CopySource=settings.DNB_MONITORING_S3_BUCKET + '/' + file_name)
         self.s3_client.Object(settings.DNB_MONITORING_S3_BUCKET, file_name).delete()
 
+    def _sum_total(self, summary):
+        return sum(line['total'] - line['failed'] for line in summary)
+
     def handle(self, *args, **options):
         files = self._list_files()
 
@@ -78,6 +81,8 @@ class Command(BaseCommand):
 
         summary_text = '\n'.join(
             '{file}\t\tTotal: {total}\tFailed: {failed}'.format(**line) for line in summary)
+
+        logger.info(f'A total of {self._sum_total(summary)} companies were updated.')
 
         if summary_text:
             self.stdout.write(summary_text)

--- a/dnb_direct_plus/tests/test_management.py
+++ b/dnb_direct_plus/tests/test_management.py
@@ -113,7 +113,7 @@ class TestProcessMonitoringData:
         if archive_file:
             mocked_archive_file.assert_called_once_with(file_name)
 
-    def test_processed_file_success(self, mocker, cmpelk_api_response_json):
+    def test_processed_file_success(self, mocker, cmpelk_api_response_json, caplog):
         company = CompanyFactory()
 
         update_data = [{
@@ -145,6 +145,7 @@ class TestProcessMonitoringData:
         mocked_list_files.return_value = [file_name]
 
         out = StringIO()
+        caplog.set_level('INFO')
 
         call_command('process_monitoring_data', stdout=out)
 
@@ -154,4 +155,4 @@ class TestProcessMonitoringData:
         assert record.file_name == file_name
         assert record.total == 2
         assert record.failed == 1
-
+        assert caplog.messages[-1] == 'A total of 1 companies were updated.'


### PR DESCRIPTION
This adds the code to log total number of companies that were updated after the retrieval and processing of company update files from the DNB monitoring bucket.