### PR TITLE
Remove count from paginator

### DIFF
--- a/api/pagination.py
+++ b/api/pagination.py
@@ -5,13 +5,6 @@ from rest_framework.response import Response
 class CustomCursorPagination(CursorPagination):
     page_size_query_param = 'page_size'
 
-    def paginate_queryset(self, queryset, request, view=None):
-        """
-        Override paginate_queryset() to ensure that a count is set on the CustomCursorPagination instance.
-        """
-        self.count = queryset.count()
-        return super().paginate_queryset(queryset, request, view)
-
     def get_paginated_response(self, data):
         """
         Respond with a custom response format which includes a count of the total records in the queryset.
@@ -19,6 +12,5 @@ class CustomCursorPagination(CursorPagination):
         return Response({
             'next': self.get_next_link(),
             'previous': self.get_previous_link(),
-            'count': self.count,
             'results': data,
         })

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -136,7 +136,6 @@ class TestCompanyUpdateView:
         assert response.json() == {
             'next': None,
             'previous': None,
-            'count': 1,
             'results': [
                 expected_company_data
             ],
@@ -167,7 +166,6 @@ class TestCompanyUpdateView:
 
         result_data = response.json()
         assert len(result_data['results']) == 2
-        assert result_data['count'] == 2
         assert all(result['duns_number'] in duns_numbers for result in result_data['results'])
 
     @freeze_time('2019-11-25 12:00:01 UTC')
@@ -185,7 +183,6 @@ class TestCompanyUpdateView:
         response_data = response.json()
         assert response_data['next'] is not None
         assert len(response_data['results']) == 1
-        assert response_data['count'] == 2
         assert response_data['results'][0]['duns_number'] == company1.duns_number
 
         response = auth_client.get(


### PR DESCRIPTION
This removes the count attribute from the paginator.

This can only be merged after: https://github.com/uktrade/data-hub-api/pull/2837