### PR TITLE
Fix notify csv uploads

### DIFF
--- a/company/tests/test_tasks.py
+++ b/company/tests/test_tasks.py
@@ -101,7 +101,7 @@ class TestSendPendingChangeRequests:
                     template_id=TEMPLATE_IDS['change-request'],
                     personalisation={
                         'batch_identifier': 'Monday 25 November 2019',
-                        'link_to_file': {'file': expected_batch_1_encoded},
+                        'link_to_file': {'file': expected_batch_1_encoded, 'is_csv': True},
                     },
                 ),
                 mock.call(
@@ -109,7 +109,7 @@ class TestSendPendingChangeRequests:
                     template_id=TEMPLATE_IDS['change-request'],
                     personalisation={
                         'batch_identifier': 'Monday 25 November 2019 Part 2',
-                        'link_to_file': {'file': expected_batch_2_encoded},
+                        'link_to_file': {'file': expected_batch_2_encoded, 'is_csv': True},
                     },
                 ),
             ],
@@ -195,6 +195,6 @@ class TestSendPendingInvestigationRequests:
             template_id=TEMPLATE_IDS['investigation-request'],
             personalisation={
                 'batch_identifier': 'Monday 25 November 2019',
-                'link_to_file': {'file': b64encode(csv_bytes).decode('ascii')},
+                'link_to_file': {'file': b64encode(csv_bytes).decode('ascii'), 'is_csv': True},
             },
         )

--- a/company/tests/test_utils.py
+++ b/company/tests/test_utils.py
@@ -111,7 +111,8 @@ class TestSendChangeRequestBatch:
                     {
                         'batch_identifier': 'Batch 1',
                         'link_to_file': mocked_generate_change_request_csv.return_value,
-                    }
+                    },
+                    is_csv=True,
                 ),
                 mock.call(
                     'bar@example.net',
@@ -119,7 +120,8 @@ class TestSendChangeRequestBatch:
                     {
                         'batch_identifier': 'Batch 1',
                         'link_to_file': mocked_generate_change_request_csv.return_value,
-                    }
+                    },
+                    is_csv=True,
                 ),
             ]
         )
@@ -251,7 +253,8 @@ class TestSendInvestigationRequestBatch:
             {
                 'batch_identifier': 'Batch 1',
                 'link_to_file': mock.ANY,
-            }
+            },
+            is_csv=True,
         )
         assert mock_notify.call_count == 2
         assert mock_notify.call_args[0][2]['link_to_file'].getvalue() == csv_bytes

--- a/company/utils.py
+++ b/company/utils.py
@@ -78,7 +78,7 @@ def send_change_request_batch(change_requests, batch_identifier):
         'link_to_file': generate_change_request_csv(change_requests),
     }
     for email_address in settings.CHANGE_REQUESTS_RECIPIENTS:
-        notify_by_email(email_address, TEMPLATE_IDS['change-request'], context)
+        notify_by_email(email_address, TEMPLATE_IDS['change-request'], context, is_csv=True)
     submitted_on = now()
     for change_request in change_requests:
         change_request.mark_as_submitted(submitted_on)
@@ -149,7 +149,8 @@ def send_investigation_request_batch(investigation_requests, batch_identifier):
         notify_by_email(
             email_address,
             TEMPLATE_IDS['investigation-request'],
-            context
+            context,
+            is_csv=True,
         )
 
     submitted_on = now()

--- a/core/notify.py
+++ b/core/notify.py
@@ -14,7 +14,7 @@ TEMPLATE_IDS = {
 }
 
 
-def notify_by_email(email_address, template_identifier, context):
+def notify_by_email(email_address, template_identifier, context, is_csv=False):
     """
     Notify an email address, using a GOVUK notify template and some template
     context.
@@ -23,7 +23,7 @@ def notify_by_email(email_address, template_identifier, context):
     # to an uploadable string
     for key, value in context.items():
         if isinstance(value, io.IOBase):
-            context[key] = prepare_upload(value)
+            context[key] = prepare_upload(value, is_csv=is_csv)
     response = notifications_client.send_email_notification(
         email_address=email_address,
         template_id=template_identifier,

--- a/core/tests/test_notify.py
+++ b/core/tests/test_notify.py
@@ -35,7 +35,7 @@ def test_notify_by_email_with_file(monkeypatch):
     }
     expected_personalisation = {
         **context,
-        'file': {'file': 'Zm9vIGJhciBiYXo='},
+        'file': {'file': 'Zm9vIGJhciBiYXo=', 'is_csv': False},
     }
     notify_by_email(email_address, template_id, context)
     notifications_client_mock.send_email_notification.assert_called_with(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,87 +4,90 @@
 #
 #    pip-compile --output-file=requirements-dev.txt requirements-dev.in
 #
-amqp==2.4.2
+amqp==2.4.2               # via -r requirements.txt (line 7), kombu
 argh==0.26.2              # via watchdog
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
-backoff==1.8.0
-billiard==3.6.0.0
-boto3==1.9.130
-boto==2.49.0
-botocore==1.12.130
-celery==4.3.0
-certifi==2019.3.9
-chardet==3.0.4
-codecov==2.0.22
+backoff==1.8.0            # via -r requirements.txt (line 8)
+billiard==3.6.0.0         # via -r requirements.txt (line 9), celery
+boto3==1.9.130            # via -r requirements.txt (line 10), smart-open
+boto==2.49.0              # via -r requirements.txt (line 11), smart-open
+botocore==1.12.130        # via -r requirements.txt (line 12), boto3, s3transfer
+celery==4.3.0             # via -r requirements.txt (line 13), django-celery-beat, django-celery-results
+certifi==2019.3.9         # via -r requirements.txt (line 14), requests, sentry-sdk
+chardet==3.0.4            # via -r requirements.txt (line 15), requests
+codecov==2.0.22           # via -r requirements-dev.in (line 25)
 coverage==4.5.1           # via codecov, pytest-cov
-dj-database-url==0.5.0
-django-celery-beat==1.4.0
-django-celery-results==1.0.4
-django-environ==0.4.5
-django-extensions==2.2.8
-django-prometheus==1.0.15
-django-rest-framework==0.1.0
-django-staff-sso-client==0.2.0
-django-timezone-field==3.0
-django==2.2.10
-djangorestframework==3.9.2
-docopt==0.6.2
-docutils==0.14
+dj-database-url==0.5.0    # via -r requirements.txt (line 16)
+django-celery-beat==1.4.0  # via -r requirements.txt (line 17)
+django-celery-results==1.0.4  # via -r requirements.txt (line 18)
+django-environ==0.4.5     # via -r requirements.txt (line 19)
+django-extensions==2.2.8  # via -r requirements-dev.in (line 23)
+django-prometheus==1.0.15  # via -r requirements.txt (line 20)
+django-rest-framework==0.1.0  # via -r requirements.txt (line 21)
+django-staff-sso-client==0.2.0  # via -r requirements.txt (line 22)
+django-timezone-field==3.0  # via -r requirements.txt (line 23), django-celery-beat
+django==2.2.10            # via -r requirements.txt (line 24), django-staff-sso-client, django-timezone-field
+djangorestframework==3.9.2  # via -r requirements.txt (line 25), django-rest-framework
+docopt==0.6.2             # via -r requirements.txt (line 26), notifications-python-client
+docutils==0.14            # via -r requirements-dev.in (line 22), -r requirements.txt (line 27), botocore
 entrypoints==0.3          # via flake8
-factory-boy==2.12.0
+factory-boy==2.12.0       # via -r requirements-dev.in (line 19)
 faker==2.0.4              # via factory-boy
-flake8-blind-except==0.1.1
-flake8-debugger==3.1.0
-flake8-import-order==0.18.1
-flake8-print==3.1.0
-flake8-quotes==2.0.1
-flake8==3.7.7
-freezegun==0.3.12
-future==0.18.2
-gunicorn==19.9.0
-idna==2.8
+flake8-blind-except==0.1.1  # via -r requirements-dev.in (line 4)
+flake8-debugger==3.1.0    # via -r requirements-dev.in (line 5)
+flake8-import-order==0.18.1  # via -r requirements-dev.in (line 6)
+flake8-print==3.1.0       # via -r requirements-dev.in (line 7)
+flake8-quotes==2.0.1      # via -r requirements-dev.in (line 8)
+flake8==3.7.7             # via -r requirements-dev.in (line 9), flake8-debugger, flake8-print, flake8-quotes
+freezegun==0.3.12         # via -r requirements-dev.in (line 12)
+future==0.18.2            # via -r requirements.txt (line 28), notifications-python-client
+gunicorn==19.9.0          # via -r requirements.txt (line 29)
+idna==2.8                 # via -r requirements.txt (line 30), requests
 importlib-metadata==0.18  # via pluggy, pytest
-jmespath==0.9.4
-kombu==4.5.0
+jmespath==0.9.4           # via -r requirements.txt (line 31), boto3, botocore
+kombu==4.5.0              # via -r requirements.txt (line 32), celery
 mccabe==0.6.1             # via flake8
-monotonic==1.5
+monotonic==1.5            # via -r requirements.txt (line 33), notifications-python-client
 more-itertools==7.0.0     # via pytest
-notifications-python-client==5.5.1
-oauthlib==3.0.1
+notifications-python-client==5.6.0  # via -r requirements.txt (line 34)
+oauthlib==3.0.1           # via -r requirements.txt (line 35), requests-oauthlib
 packaging==19.0           # via pytest
 pathtools==0.1.2          # via watchdog
 pluggy==0.12.0            # via pytest
-prometheus-client==0.7.1
-psycopg2==2.8.1
+prometheus-client==0.7.1  # via -r requirements.txt (line 36), django-prometheus
+psycopg2==2.8.1           # via -r requirements.txt (line 37)
 py==1.8.0                 # via pytest
 pycodestyle==2.5.0        # via flake8, flake8-debugger, flake8-import-order, flake8-print
 pyflakes==2.1.1           # via flake8
-pyjwt==1.7.1
+pyjwt==1.7.1              # via -r requirements.txt (line 38), notifications-python-client
 pyparsing==2.4.0          # via packaging
-pytest-cov==2.7.1
-pytest-django==3.5.0
-pytest-env==0.6.2
-pytest-mock==1.10.4
-pytest==4.6.3
-python-crontab==2.3.6
-python-dateutil==2.8.0
-pytz==2018.9
-pyyaml==5.1
-raven==6.10.0
-redis==3.2.1
-requests-mock==1.6.0
-requests-oauthlib==1.2.0
-requests==2.21.0
-s3transfer==0.2.0
-sentry-sdk==0.9.0
-six==1.12.0
-smart-open==1.9.0
-sqlparse==0.3.0
+pytest-cov==2.7.1         # via -r requirements-dev.in (line 13)
+pytest-django==3.5.0      # via -r requirements-dev.in (line 14)
+pytest-env==0.6.2         # via -r requirements-dev.in (line 15)
+pytest-mock==1.10.4       # via -r requirements-dev.in (line 16)
+pytest==4.6.3             # via -r requirements-dev.in (line 17), pytest-cov, pytest-django, pytest-env, pytest-mock
+python-crontab==2.3.6     # via -r requirements.txt (line 39), django-celery-beat
+python-dateutil==2.8.0    # via -r requirements.txt (line 40), botocore, faker, freezegun, python-crontab
+pytz==2018.9              # via -r requirements.txt (line 41), celery, django, django-timezone-field
+pyyaml==5.1               # via -r requirements.txt (line 42), watchdog
+raven==6.10.0             # via -r requirements.txt (line 43), django-staff-sso-client
+redis==3.2.1              # via -r requirements.txt (line 44)
+requests-mock==1.6.0      # via -r requirements-dev.in (line 18)
+requests-oauthlib==1.2.0  # via -r requirements.txt (line 45), django-staff-sso-client
+requests==2.21.0          # via -r requirements.txt (line 46), codecov, notifications-python-client, requests-mock, requests-oauthlib, smart-open
+s3transfer==0.2.0         # via -r requirements.txt (line 47), boto3
+sentry-sdk==0.9.0         # via -r requirements.txt (line 48)
+six==1.12.0               # via -r requirements.txt (line 49), django-extensions, faker, flake8-print, freezegun, packaging, pytest, python-dateutil, requests-mock
+smart-open==1.9.0         # via -r requirements.txt (line 50)
+sqlparse==0.3.0           # via -r requirements.txt (line 51), django
 text-unidecode==1.3       # via faker
-urllib3==1.24.3
-vine==1.3.0
-watchdog[watchmedo]==0.10.2
+urllib3==1.24.3           # via -r requirements.txt (line 52), botocore, requests, sentry-sdk
+vine==1.3.0               # via -r requirements.txt (line 53), amqp, celery
+watchdog[watchmedo]==0.10.2  # via -r requirements-dev.in (line 24)
 wcwidth==0.1.7            # via pytest
-whitenoise==4.1.2
+whitenoise==4.1.2         # via -r requirements.txt (line 54)
 zipp==0.5.1               # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements.in
+++ b/requirements.in
@@ -15,7 +15,7 @@ sentry-sdk
 backoff
 django-prometheus
 smart-open
-notifications-python-client==5.5.1
+notifications-python-client==5.6.0
 
 whitenoise
 gunicorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ idna==2.8                 # via requests
 jmespath==0.9.4           # via boto3, botocore
 kombu==4.5.0              # via celery
 monotonic==1.5            # via notifications-python-client
-notifications-python-client==5.5.1  # via -r requirements.in (line 18)
+notifications-python-client==5.6.0  # via -r requirements.in (line 18)
 oauthlib==3.0.1           # via requests-oauthlib
 prometheus-client==0.7.1  # via django-prometheus
 psycopg2==2.8.1           # via -r requirements.in (line 6)


### PR DESCRIPTION
This PR uses the new `is_csv` flag for files uploaded to notify in order to ensure that change request/investigation spreadsheet files are downloaded with .csv extensions instead of .txt.

I've tested this end to end manually by running the celery task to send pending change requests to my own inbox through our dev notify API key.