### PR TITLE
Add utf8 BOM to CSV responses to provide encoding hinting

### DIFF
--- a/company/tests/conftest.py
+++ b/company/tests/conftest.py
@@ -1,3 +1,4 @@
+import codecs
 import io
 
 import pytest
@@ -12,7 +13,7 @@ def get_csv_bytes():
     """
     def _get_csv_bytes(investigation):
         return io.BytesIO(
-            generate_investigation_request_csv(
+            codecs.BOM_UTF8 + generate_investigation_request_csv(
                 investigation,
             ).getvalue().encode('utf-8')
         ).getvalue()

--- a/company/tests/test_tasks.py
+++ b/company/tests/test_tasks.py
@@ -1,3 +1,4 @@
+import codecs
 from base64 import b64encode
 from unittest import mock
 
@@ -87,11 +88,11 @@ class TestSendPendingChangeRequests:
         # Simulate the effect of notifications_python_client.utils.prepare_upload to set expected file content
         # See: https://github.com/alphagov/notifications-python-client/blob/master/notifications_python_client/utils.py
         expected_batch_1 = (
-            b"duns_number,changes\r\n000000005,Business Name: foo; Trading Name(s): ['foo ltd']\r\n000000006,"
+            codecs.BOM_UTF8 + b"duns_number,changes\r\n000000005,Business Name: foo; Trading Name(s): ['foo ltd']\r\n000000006,"
             b'Business Name: bar\r\n'
         )
         expected_batch_1_encoded = b64encode(expected_batch_1).decode('ascii')
-        expected_batch_2 = b'duns_number,changes\r\n000000007,Business Name: baz\r\n'
+        expected_batch_2 = codecs.BOM_UTF8 + b'duns_number,changes\r\n000000007,Business Name: baz\r\n'
         expected_batch_2_encoded = b64encode(expected_batch_2).decode('ascii')
 
         mocked_send_email_notification.assert_has_calls(

--- a/company/tests/test_utils.py
+++ b/company/tests/test_utils.py
@@ -69,7 +69,7 @@ class TestGenerateChangeRequestCSV:
         ]
         csv_file = generate_change_request_csv([partial_change_request, full_change_request])
         # Convert the byte file object in to a string
-        csv_file_contents = csv_file.read().decode('utf-8')
+        csv_file_contents = csv_file.read().decode('utf-8-sig')
         # Put the string CSV content in to a StringIO object so that we can use the csv module to read it
         csv_file_stringio = io.StringIO(csv_file_contents)
         reader = csv.reader(csv_file_stringio, dialect='excel', delimiter=',')
@@ -297,4 +297,4 @@ class TestSendInvestigationRequestBatch:
             )
 
         assert investigation_request.status == InvestigationRequestStatus.pending.name
-        assert investigation_request.submitted_on == None
+        assert investigation_request.submitted_on is None

--- a/company/utils.py
+++ b/company/utils.py
@@ -1,4 +1,5 @@
 import io
+import codecs
 import csv
 from copy import deepcopy
 
@@ -45,7 +46,7 @@ def _get_change_request_row(change_request):
 
 def _convert_stringio_to_bytesio(stringio_file):
     stringio_file.seek(0)
-    bytesio_file = io.BytesIO(stringio_file.read().encode('utf-8'))
+    bytesio_file = io.BytesIO(codecs.BOM_UTF8 + stringio_file.read().encode('utf-8'))
     return bytesio_file
 
 


### PR DESCRIPTION
We had a problem with the spreadsheets that we are sending out nightly - MS Excel would assume Ascii character encoding so utf-8 special characters would not render correctly.  Other spreadsheet applications dealt with things sensibly, but Excel likely accounts for a large proportion of our user base.

This PR adds in some encoding hinting that Excel needs to deal with things correctly.  See this SO post for more detail: https://stackoverflow.com/questions/155097/microsoft-excel-mangles-diacritics-in-csv-files 