### PR TITLE
Add exception handling to Notify API call

### DIFF
--- a/core/notify.py
+++ b/core/notify.py
@@ -29,4 +29,5 @@ def notify_by_email(email_address, template_identifier, context, is_csv=False):
         template_id=template_identifier,
         personalisation=context,
     )
+    response.raise_for_status()
     return response


### PR DESCRIPTION
This PR adds exception handling to Notify calls.

This would mean that any exception for a given batch of change-requests or new company investigations will not block the subsequent batches from being sent.

