### PR TITLE
Bugfix/notify errors

### DIFF
--- a/company/tests/test_tasks.py
+++ b/company/tests/test_tasks.py
@@ -137,7 +137,7 @@ class TestSendPendingChangeRequests:
             mock_notify.send_email_notification = mock.Mock()
             mock_notify.send_email_notification.side_effect = (
                 HTTPError(response=mock.Mock(status_code=400)),
-                mock.Mock(status_code=200),
+                {},
             )
 
             send_pending_change_requests.apply()
@@ -253,7 +253,7 @@ class TestSendPendingInvestigationRequests:
             mock_notify.send_email_notification = mock.Mock()
             mock_notify.send_email_notification.side_effect = (
                 HTTPError(response=mock.Mock(status_code=400)),
-                mock.Mock(status_code=200),
+                {},
             )
 
             send_pending_investigation_requests.apply()

--- a/core/notify.py
+++ b/core/notify.py
@@ -3,6 +3,7 @@ import io
 from django.conf import settings
 from notifications_python_client import prepare_upload
 from notifications_python_client.notifications import NotificationsAPIClient
+from requests.exceptions import HTTPError
 
 
 notifications_client = NotificationsAPIClient(settings.GOVUK_NOTIFICATIONS_API_KEY)
@@ -29,5 +30,6 @@ def notify_by_email(email_address, template_identifier, context, is_csv=False):
         template_id=template_identifier,
         personalisation=context,
     )
-    response.raise_for_status()
+    if isinstance(response, HTTPError):
+        response.raise_for_status()
     return response


### PR DESCRIPTION
This fixes a bug in #74 

The reason for the bug was inconsistent return type for the `send_email_notification` function.

Here is the [error](https://sentry.ci.uktrade.digital/dit/external-company-service/issues/27062/?query=is%3Aunresolved) in Sentry.