### PR TITLE
Add migration to update faulty investigation company details

### DIFF
--- a/company/migrations/0017_update_company_details.py
+++ b/company/migrations/0017_update_company_details.py
@@ -1,0 +1,25 @@
+import django.contrib.postgres.fields.jsonb
+from django.db import migrations
+
+def update_company_details_telephone(apps, schema_editor):
+    faulty_string = '\u0003'
+    InvestigationRequest = apps.get_model('company', 'InvestigationRequest')
+    records = InvestigationRequest.objects.all()
+
+    for record in records:
+        if faulty_string in record.company_details['telephone']:
+            details = record.company_details
+            details['telephone'] = details['telephone'].replace(faulty_string, '')
+
+            record.company_details = details
+            record.save()
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('company', '0016_auto_20200430_1332'),
+    ]
+
+    operations = [
+        migrations.RunPython(update_company_details_telephone),
+    ]


### PR DESCRIPTION
The intent of this PR is to fix data causing the pending investigation request email to be submitted properly.

We will then work on the root cause of the issue to prevent from this happening again by applying a validation fix in the form submission in the FE.