### PR TITLE
Ensure telephone check is applied if key exists

### DIFF
--- a/company/migrations/0017_update_company_details.py
+++ b/company/migrations/0017_update_company_details.py
@@ -7,12 +7,13 @@ def update_company_details_telephone(apps, schema_editor):
     records = InvestigationRequest.objects.all()
 
     for record in records:
-        if faulty_string in record.company_details['telephone']:
-            details = record.company_details
-            details['telephone'] = details['telephone'].replace(faulty_string, '')
+        if 'telephone' in record.company_details:
+            if faulty_string in record.company_details['telephone']:
+                details = record.company_details
+                details['telephone'] = details['telephone'].replace(faulty_string, '')
 
-            record.company_details = details
-            record.save()
+                record.company_details = details
+                record.save()
 
 class Migration(migrations.Migration):
 


### PR DESCRIPTION
Some company details come without a telephone number, causing the migration script to fail. added a check to ensure it only goes further if telephone key is present.