### PR TITLE
Revert "Bump djangorestframework from 3.9.2 to 3.11.2"

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -79,8 +79,7 @@ django==2.2.18
     #   -r requirements.txt
     #   django-staff-sso-client
     #   django-timezone-field
-    #   djangorestframework
-djangorestframework==3.11.2
+djangorestframework==3.9.2
     # via
     #   -r requirements.txt
     #   django-rest-framework

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,8 +53,7 @@ django==2.2.18
     #   -r requirements.in
     #   django-staff-sso-client
     #   django-timezone-field
-    #   djangorestframework
-djangorestframework==3.11.2
+djangorestframework==3.9.2
     # via django-rest-framework
 docopt==0.6.2
     # via notifications-python-client


### PR DESCRIPTION
Reverts uktrade/dnb-service#85 - a dependabot security update that did not cause a failure in pre-commit tests, but failed the ci pipeline after merging. 

https://jenkins.ci.uktrade.digital/job/ci-pipeline/53874/console - possibly due to a python version mismatch.