### PR TITLE
Update Python version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.5
+FROM python:3.8.6
 
 RUN apt-get update && apt-get install -y wget
 

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.8.5
+python-3.8.6


### PR DESCRIPTION
The Python version is currently set as 3.8.5, which is not supported by Jenkins. This PR updates it to 3.8.6, which is.