### PR TITLE
Update urlllib3

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -21,4 +21,4 @@ elastic-apm
 whitenoise
 gunicorn
 
-urllib3>=1.24.2
+urllib3>=1.26.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,133 +4,147 @@
 #
 #    pip-compile
 #
-amqp==2.4.2
+amqp==5.0.6
     # via kombu
-backoff==1.8.0
+backoff==1.10.0
     # via -r requirements.in
-billiard==3.6.0.0
+billiard==3.6.4.0
     # via celery
-boto3==1.9.130
-    # via
-    #   -r requirements.in
-    #   smart-open
-boto==2.49.0
-    # via smart-open
-botocore==1.12.130
+boto3==1.17.85
+    # via -r requirements.in
+botocore==1.20.85
     # via
     #   boto3
     #   s3transfer
-celery==4.3.0
+celery==5.1.0
     # via
     #   -r requirements.in
     #   django-celery-beat
     #   django-celery-results
-certifi==2019.3.9
+certifi==2021.5.30
     # via
     #   elastic-apm
     #   requests
     #   sentry-sdk
-chardet==3.0.4
+chardet==4.0.0
     # via requests
+click-didyoumean==0.0.3
+    # via celery
+click-plugins==1.1.1
+    # via celery
+click-repl==0.2.0
+    # via celery
+click==7.1.2
+    # via
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
 dj-database-url==0.5.0
     # via -r requirements.in
-django-celery-beat==1.4.0
+django-celery-beat==2.2.0
     # via -r requirements.in
-django-celery-results==1.0.4
+django-celery-results==2.0.1
     # via -r requirements.in
 django-environ==0.4.5
     # via -r requirements.in
-django-prometheus==1.0.15
+django-prometheus==2.1.0
     # via -r requirements.in
 django-rest-framework==0.1.0
     # via -r requirements.in
-django-staff-sso-client==0.2.0
+django-staff-sso-client==3.1.0
     # via -r requirements.in
-django-timezone-field==3.0
+django-timezone-field==4.1.2
     # via django-celery-beat
 django==2.2.20
     # via
     #   -r requirements.in
+    #   django-celery-beat
     #   django-staff-sso-client
     #   django-timezone-field
     #   djangorestframework
-djangorestframework==3.11.2
+djangorestframework==3.12.4
     # via django-rest-framework
 docopt==0.6.2
     # via notifications-python-client
-docutils==0.14
-    # via botocore
-elastic-apm==5.7.0
+elastic-apm==6.2.0
     # via -r requirements.in
 future==0.18.2
     # via notifications-python-client
-gunicorn==19.9.0
+gunicorn==20.1.0
     # via -r requirements.in
-idna==2.8
+idna==2.10
     # via requests
-jmespath==0.9.4
+jmespath==0.10.0
     # via
     #   boto3
     #   botocore
-kombu==4.5.0
+kombu==5.1.0
     # via celery
-monotonic==1.5
+monotonic==1.6
     # via notifications-python-client
 notifications-python-client==5.6.0
     # via -r requirements.in
-oauthlib==3.0.1
+oauthlib==3.1.1
     # via requests-oauthlib
-prometheus-client==0.7.1
+prometheus-client==0.11.0
     # via django-prometheus
-psycopg2==2.8.1
+prompt-toolkit==3.0.18
+    # via click-repl
+psycopg2==2.8.6
     # via -r requirements.in
-pyjwt==1.7.1
+pyjwt==2.1.0
     # via notifications-python-client
-python-crontab==2.3.6
+python-crontab==2.5.1
     # via django-celery-beat
-python-dateutil==2.8.0
+python-dateutil==2.8.1
     # via
     #   botocore
     #   python-crontab
-pytz==2018.9
+pytz==2021.1
     # via
     #   celery
     #   django
     #   django-timezone-field
-pyyaml==5.4
+pyyaml==5.4.1
     # via -r requirements.in
-raven==6.10.0
-    # via django-staff-sso-client
-redis==3.2.1
+redis==3.5.3
     # via -r requirements.in
-requests-oauthlib==1.2.0
+requests-oauthlib==1.3.0
     # via django-staff-sso-client
-requests==2.21.0
+requests==2.25.1
     # via
     #   -r requirements.in
     #   notifications-python-client
     #   requests-oauthlib
-    #   smart-open
-s3transfer==0.2.0
+s3transfer==0.4.2
     # via boto3
-sentry-sdk==0.9.0
+sentry-sdk==1.1.0
     # via -r requirements.in
-six==1.12.0
-    # via python-dateutil
-smart-open==1.9.0
+six==1.16.0
+    # via
+    #   click-repl
+    #   python-dateutil
+smart-open==5.1.0
     # via -r requirements.in
-sqlparse==0.3.0
+sqlparse==0.4.1
     # via django
-urllib3==1.24.3
+urllib3==1.26.5
     # via
     #   -r requirements.in
     #   botocore
     #   elastic-apm
     #   requests
     #   sentry-sdk
-vine==1.3.0
+vine==5.0.0
     # via
     #   amqp
     #   celery
-whitenoise==4.1.2
+    #   kombu
+wcwidth==0.2.5
+    # via prompt-toolkit
+whitenoise==5.2.0
     # via -r requirements.in
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools


### PR DESCRIPTION
This PR fixes the `urllib3` vulnerability. In order to update to the latest version, various other dependencies needed to be updated.