### PR TITLE
CDS-238 incompatibility in notifications-python-client/pyjwt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ coverage.xml
 *.log
 local_settings.py
 db.sqlite3
+config/custom.py
 
 # Flask stuff:
 instance/
@@ -102,3 +103,12 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# docker things
+docker-compose.override.yml
+
+# Pyright
+pyrightconfig.json
+
+# Ctags
+tags

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -130,10 +130,6 @@ flake8==3.7.7
     #   flake8-quotes
 freezegun==0.3.12
     # via -r requirements-dev.in
-future==0.18.2
-    # via
-    #   -r requirements.txt
-    #   notifications-python-client
 gunicorn==20.1.0
     # via -r requirements.txt
 idna==2.10
@@ -155,13 +151,9 @@ kombu==5.1.0
     #   celery
 mccabe==0.6.1
     # via flake8
-monotonic==1.6
-    # via
-    #   -r requirements.txt
-    #   notifications-python-client
 more-itertools==7.0.0
     # via pytest
-notifications-python-client==5.6.0
+notifications-python-client==6.2.1
     # via -r requirements.txt
 oauthlib==3.1.1
     # via
@@ -300,3 +292,6 @@ whitenoise==5.2.0
     # via -r requirements.txt
 zipp==0.5.1
     # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements.in
+++ b/requirements.in
@@ -15,7 +15,7 @@ sentry-sdk
 backoff
 django-prometheus
 smart-open
-notifications-python-client==5.6.0
+notifications-python-client==6.2.1
 elastic-apm
 
 whitenoise

--- a/requirements.txt
+++ b/requirements.txt
@@ -69,8 +69,6 @@ docopt==0.6.2
     # via notifications-python-client
 elastic-apm==6.2.0
     # via -r requirements.in
-future==0.18.2
-    # via notifications-python-client
 gunicorn==20.1.0
     # via -r requirements.in
 idna==2.10
@@ -81,9 +79,7 @@ jmespath==0.10.0
     #   botocore
 kombu==5.1.0
     # via celery
-monotonic==1.6
-    # via notifications-python-client
-notifications-python-client==5.6.0
+notifications-python-client==6.2.1
     # via -r requirements.in
 oauthlib==3.1.1
     # via requests-oauthlib


### PR DESCRIPTION
We need to increment the notification-python-client version; I was able to reproduce this error $SENTRY_URL/organizations/dit/issues/41715/ locally in my dnb virtualenv:

```
 I  (e) dnb-service  …  Ma  DI  dnb-service   master ✚ 1 … 4 ⚑ 8  python
Python 3.8.10 (default, Jun  2 2021, 10:49:15)
[GCC 9.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
 I >>> import jwt
 I >>> foo = jwt.encode(payload={'iss':'iamaclientid','iat':3131241232},key='iamsosecret',headers={'typ':'JWT','alg':'HS256'})
 I >>> foo.decode
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'str' object has no attribute 'decode'
```
Looks like pyjwt moved to returning ordinary strings from jwt.encode as of v2.0.0: https://pyjwt.readthedocs.io/en/stable/changelog.html#jwt-encode-return-type