### PR TITLE
Use data-infrastructure-shared-network for data-hub<->data-flow compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 start-dnb-for-data-hub-api:
-	[ -z "$(shell docker network ls --filter=name=dh_default -q)" ] && docker network create dh_default || echo 'dh_default network already present'
+	[ -z "$(shell docker network ls --filter=name=data-infrastructure-shared-network -q)" ] && docker network create data-infrastructure-shared-network || echo 'data-infrastructure-shared-network network already present'
 	docker-compose -p dnb-service -f ../dnb-service/docker-compose.data-hub-api.yml up &
 
 stop-dnb-for-data-hub-api:

--- a/docker-compose.data-hub-api.yml
+++ b/docker-compose.data-hub-api.yml
@@ -42,11 +42,11 @@ services:
     image: redis:3.2
     restart: always
 
-# Note: The `dh_default` network is created by running `make start-*` within `data-hub-frontend`.
+# Note: The `data-infrastructure-shared-network` network is created by running `make start-*` within `data-hub-frontend`.
 # `make start-dev` or other start command must be run prior to `docker-compose -f ./docker-compose.data-hub-api.yml up`
 # otherwise the network won't exist
 networks:
   default:
     external:
-      name: dh_default
+      name: data-infrastructure-shared-network
 


### PR DESCRIPTION
data-hub-api is moving over to using data-infrastructure-shared-network
so it can communicate with data-flow. This change is to ensure
compatbility with data-hub-api after this change


## Linked PRs
* https://github.com/uktrade/data-hub-frontend/pull/4138
* https://github.com/uktrade/data-hub-api/pull/3805
