### PR TITLE
Fixing DnB company data mapping and results

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -23,11 +23,13 @@ def company_list_api_response_json():
                            'dnb_direct_plus/tests/api_data/company_list_test_response.json')) as f:
         return f.read()
 
+
 @pytest.fixture(scope='module')
 def company_list_v2_api_response_json():
     with open(os.path.join(os.path.dirname(__file__),
                            'dnb_direct_plus/tests/api_data/company_list_v2_test_response.json')) as f:
         return f.read()
+
 
 @pytest.fixture(scope='module')
 def company_list_v2_expected_data_json():
@@ -35,8 +37,16 @@ def company_list_v2_expected_data_json():
                            'dnb_direct_plus/tests/api_data/company_list_v2_populated_region.json')) as f:
         return f.read()
 
+
 @pytest.fixture(scope='module')
 def data_duns_api_response_json():
     with open(os.path.join(os.path.dirname(__file__),
                            'dnb_direct_plus/tests/api_data/data_duns_test_response.json')) as f:
+        return f.read()
+
+
+@pytest.fixture(scope='module')
+def company_by_duns_v1_api_response_json():
+    with open(os.path.join(os.path.dirname(__file__),
+                           'dnb_direct_plus/tests/api_data/company_by_duns_v1_test_response.json')) as f:
         return f.read()

--- a/dnb_direct_plus/api.py
+++ b/dnb_direct_plus/api.py
@@ -116,7 +116,14 @@ def company_list_search_v2(query, update_local=False):
         duns_number = query['duns_number']
         company = company_by_duns(duns_number)
         update_company_and_enable_monitoring(company)
+        results = [extract_company_data(company)]
 
-    return {
-        'results': results,
-    }
+        return {
+            'results': results,
+        }
+
+    else:
+
+        return {
+            'results': results,
+        }

--- a/dnb_direct_plus/mapping.py
+++ b/dnb_direct_plus/mapping.py
@@ -160,6 +160,17 @@ def extract_employee_numbers(company_data):
     return is_estimated, employee_data['value']
 
 
+def extract_domain(company_data):
+    try:
+        domain_data = company_data['organization']['websiteAddress'][0]
+        domain_url = domain_data.get('url')
+
+        return domain_url
+
+    except(KeyError, IndexError):
+        return None
+
+
 def extract_annual_sales(company_data):
 
     try:
@@ -192,7 +203,7 @@ def extract_company_data(company_data):
             company_data['organization']['corporateLinkage'].get('globalUltimate', {}).get('duns', ''),
         'global_ultimate_primary_name':
             company_data['organization']['corporateLinkage'].get('globalUltimate', {}).get('primaryName', ''),
-        'domain': company_data['organization'].get('domain', None),
+        'domain': extract_domain(company_data),
         'is_out_of_business': extract_is_out_of_business(company_data),
         **extract_address(company_data['organization']['primaryAddress']),
         **extract_registered_address(company_data),

--- a/dnb_direct_plus/tests/api_data/company_by_duns_v1_test_response.json
+++ b/dnb_direct_plus/tests/api_data/company_by_duns_v1_test_response.json
@@ -1,0 +1,632 @@
+{
+  "transactionDetail": {
+    "transactionID": "rrt-0d1158a11c3be6db6-b-eu-6022-24268338-2_4570",
+    "transactionTimestamp": "2022-03-08T14:47:46.112Z",
+    "inLanguage": "en-US",
+    "productID": "cmpelk",
+    "productVersion": "1"
+  },
+  "inquiryDetail": {
+    "productVersion": "v1",
+    "productID": "cmpelk",
+    "duns": "144709193"
+  },
+  "organization": {
+    "duns": "144709193",
+    "dunsControlStatus": {
+      "operatingStatus": {
+        "description": "Active",
+        "dnbCode": 9074
+      },
+      "isMarketable": true,
+      "isMailUndeliverable": false,
+      "isTelephoneDisconnected": false,
+      "isDelisted": false,
+      "subjectHandlingDetails": [],
+      "fullReportDate": "2021-08-27",
+      "lastUpdateDate": "2022-03-06"
+    },
+    "primaryName": "Oracle Corporation",
+    "tradeStyleNames": [
+      {
+        "name": "Oracle",
+        "priority": 1
+      }
+    ],
+    "websiteAddress": [
+      {
+        "url": "www.oracle.com",
+        "domainName": "oracle.com"
+      }
+    ],
+    "telephone": [
+      {
+        "telephoneNumber": "7378671000",
+        "isdCode": "1",
+        "isUnreachable": false
+      }
+    ],
+    "fax": [],
+    "primaryAddress": {
+      "language": {},
+      "addressCountry": {
+        "name": "United States",
+        "isoAlpha2Code": "US",
+        "fipsCode": "US"
+      },
+      "continentalRegion": {
+        "name": "North America"
+      },
+      "addressLocality": {
+        "name": "Austin"
+      },
+      "minorTownName": "None",
+      "addressRegion": {
+        "name": "Texas",
+        "abbreviatedName": "TX",
+        "fipsCode": "48"
+      },
+      "addressCounty": {
+        "name": "Travis",
+        "fipsCode": "453"
+      },
+      "postalCode": "78741-1400",
+      "postalCodePosition": {},
+      "streetNumber": "None",
+      "streetName": "None",
+      "streetAddress": {
+        "line1": "2300 Oracle Way",
+        "line2": "None"
+      },
+      "postOfficeBox": {},
+      "latitude": 30.240446,
+      "longitude": -97.72212,
+      "geographicalPrecision": {
+        "description": "Street Address Centroid",
+        "dnbCode": 30257
+      },
+      "isRegisteredAddress": false,
+      "statisticalArea": {
+        "cbsaName": "Austin-Round Rock TX",
+        "cbsaCode": "12420",
+        "economicAreaOfInfluenceCode": "013",
+        "populationRank": {
+          "rankNumber": "9",
+          "rankDnBCode": 10961,
+          "rankDescription": "500,000 +"
+        }
+      },
+      "locationOwnership": {
+        "description": "Owns",
+        "dnbCode": 1128
+      },
+      "premisesArea": {
+        "measurement": 900000.0,
+        "unitDescription": "Square Feet",
+        "unitDnBCode": 3848,
+        "reliabilityDescription": "Actual",
+        "reliabilityDnBCode": 9092
+      },
+      "isManufacturingLocation": true
+    },
+    "registeredAddress": {},
+    "mailingAddress": {},
+    "stockExchanges": [
+      {
+        "tickerName": "NYSE:ORCL",
+        "exchangeName": {
+          "description": "NYSE"
+        },
+        "exchangeCountry": {
+          "isoAlpha2Code": "US"
+        },
+        "isPrimary": true
+      },
+      {
+        "tickerName": "Buenos Aires:ORCL",
+        "exchangeName": {
+          "description": "Buenos Aires"
+        },
+        "exchangeCountry": {
+          "isoAlpha2Code": "AR"
+        },
+        "isPrimary": "None"
+      },
+      {
+        "tickerName": "Dusseldorf:ORC",
+        "exchangeName": {
+          "description": "Dusseldorf"
+        },
+        "exchangeCountry": {
+          "isoAlpha2Code": "DE"
+        },
+        "isPrimary": "None"
+      },
+      {
+        "tickerName": "German:ORC",
+        "exchangeName": {
+          "description": "German"
+        },
+        "exchangeCountry": {
+          "isoAlpha2Code": "DE"
+        },
+        "isPrimary": "None"
+      },
+      {
+        "tickerName": "Hamburg:ORC",
+        "exchangeName": {
+          "description": "Hamburg"
+        },
+        "exchangeCountry": {
+          "isoAlpha2Code": "DE"
+        },
+        "isPrimary": "None"
+      },
+      {
+        "tickerName": "Mexican:ORCL",
+        "exchangeName": {
+          "description": "Mexican"
+        },
+        "exchangeCountry": {
+          "isoAlpha2Code": "MX"
+        },
+        "isPrimary": "None"
+      },
+      {
+        "tickerName": "Munich:ORC",
+        "exchangeName": {
+          "description": "Munich"
+        },
+        "exchangeCountry": {
+          "isoAlpha2Code": "DE"
+        },
+        "isPrimary": "None"
+      },
+      {
+        "tickerName": "Santiago:ORCL",
+        "exchangeName": {
+          "description": "Santiago"
+        },
+        "exchangeCountry": {
+          "isoAlpha2Code": "CL"
+        },
+        "isPrimary": "None"
+      },
+      {
+        "tickerName": "Vienna:ORCL",
+        "exchangeName": {
+          "description": "Vienna"
+        },
+        "exchangeCountry": {
+          "isoAlpha2Code": "AT"
+        },
+        "isPrimary": "None"
+      },
+      {
+        "tickerName": "Swiss:ORCL",
+        "exchangeName": {
+          "description": "Swiss"
+        },
+        "exchangeCountry": {
+          "isoAlpha2Code": "CH"
+        },
+        "isPrimary": "None"
+      },
+      {
+        "tickerName": "Stuttgart:ORC",
+        "exchangeName": {
+          "description": "Stuttgart"
+        },
+        "exchangeCountry": {
+          "isoAlpha2Code": "DE"
+        },
+        "isPrimary": "None"
+      },
+      {
+        "tickerName": "Hannover:ORC",
+        "exchangeName": {
+          "description": "Hannover"
+        },
+        "exchangeCountry": {
+          "isoAlpha2Code": "DE"
+        },
+        "isPrimary": "None"
+      },
+      {
+        "tickerName": "XETRA:ORC",
+        "exchangeName": {
+          "description": "XETRA"
+        },
+        "exchangeCountry": {
+          "isoAlpha2Code": "DE"
+        },
+        "isPrimary": "None"
+      },
+      {
+        "tickerName": "Sao Paulo Futures:ORCL34",
+        "exchangeName": {
+          "description": "Sao Paulo Futures"
+        },
+        "exchangeCountry": {
+          "isoAlpha2Code": "BR"
+        },
+        "isPrimary": "None"
+      },
+      {
+        "tickerName": "LSE:0R1Z",
+        "exchangeName": {
+          "description": "LSE"
+        },
+        "exchangeCountry": {
+          "isoAlpha2Code": "GB"
+        },
+        "isPrimary": "None"
+      }
+    ],
+    "thirdPartyAssessment": [
+      {
+        "description": "Fortune 1000 Revenue Rank",
+        "dnbCode": 21230,
+        "assessmentDate": "2021",
+        "value": "80"
+      },
+      {
+        "description": "Fortune 500",
+        "dnbCode": 23290,
+        "assessmentDate": "2021",
+        "value": "80"
+      }
+    ],
+    "registrationNumbers": [
+      {
+        "registrationNumber": "54-2185193",
+        "typeDescription": "Federal Taxpayer Identification Number (US)",
+        "typeDnBCode": 6863
+      }
+    ],
+    "industryCodes": [
+      {
+        "code": "511210",
+        "description": "Software Publishers",
+        "typeDescription": "North American Industry Classification System 2017",
+        "typeDnBCode": 30832,
+        "priority": 1
+      },
+      {
+        "code": "1121",
+        "description": "Computer Software",
+        "typeDescription": "D&B Hoovers Industry Code",
+        "typeDnBCode": 25838,
+        "priority": 1
+      },
+      {
+        "code": "7372",
+        "description": "Prepackaged software services",
+        "typeDescription": "US Standard Industry Code 1987 - 4 digit",
+        "typeDnBCode": 399,
+        "priority": 1
+      },
+      {
+        "code": "73720000",
+        "description": "Prepackaged software",
+        "typeDescription": "D&B Standard Industry Code",
+        "typeDnBCode": 3599,
+        "priority": 1
+      },
+      {
+        "code": "I",
+        "description": "Services",
+        "typeDescription": "D&B Standard Major Industry Code",
+        "typeDnBCode": 24657,
+        "priority": 1
+      },
+      {
+        "code": "5829",
+        "description": "Other software publishing",
+        "typeDescription": "NACE Revision 2",
+        "typeDnBCode": 29104,
+        "priority": 1
+      }
+    ],
+    "businessEntityType": {
+      "description": "Corporation",
+      "dnbCode": 451
+    },
+    "controlOwnershipDate": "1977",
+    "controlOwnershipType": {
+      "description": "Publicly Traded Company",
+      "dnbCode": 9057
+    },
+    "isAgent": "None",
+    "isImporter": "None",
+    "isExporter": "None",
+    "numberOfEmployees": [
+      {
+        "value": 2300,
+        "informationScopeDescription": "Headquarters Only (Employs Here)",
+        "informationScopeDnBCode": 9068,
+        "reliabilityDescription": "Actual",
+        "reliabilityDnBCode": 9092,
+        "employeeCategories": []
+      },
+      {
+        "value": 132000,
+        "informationScopeDescription": "Consolidated",
+        "informationScopeDnBCode": 9067,
+        "reliabilityDescription": "Actual",
+        "reliabilityDnBCode": 9092,
+        "employeeCategories": [
+          {
+            "employmentBasisDescription": "Principals",
+            "employmentBasisDnBCode": 9064
+          }
+        ],
+        "trend": [
+          {
+            "timePeriod": {
+              "description": "1-3 years",
+              "dnbCode": 13711
+            },
+            "growthRate": -2.0
+          },
+          {
+            "timePeriod": {
+              "description": "1-5 years",
+              "dnbCode": 13721
+            },
+            "growthRate": 2.0
+          }
+        ]
+      }
+    ],
+    "financials": [
+      {
+        "financialStatementToDate": "2021-05-31",
+        "financialStatementDuration": "None",
+        "informationScopeDescription": "Consolidated",
+        "informationScopeDnBCode": 9067,
+        "reliabilityDescription": "Actual",
+        "reliabilityDnBCode": 9092,
+        "unitCode": "SingleUnits",
+        "accountantName": "Ernst & Young LLP, San Jose, California",
+        "yearlyRevenue": [
+          {
+            "value": 40479000000.0,
+            "currency": "USD",
+            "trend": [
+              {
+                "timePeriod": {
+                  "description": "1-5 years",
+                  "dnbCode": 13721
+                },
+                "growthRate": 2.0
+              },
+              {
+                "timePeriod": {
+                  "description": "1-3 years",
+                  "dnbCode": 13711
+                },
+                "growthRate": -2.0
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "mostSeniorPrincipals": [
+      {
+        "givenName": "Safra",
+        "familyName": "Catz",
+        "fullName": "Safra A Catz",
+        "namePrefix": "None",
+        "nameSuffix": "None",
+        "gender": "None",
+        "jobTitles": [
+          {
+            "title": "Chief Executive Officer"
+          }
+        ],
+        "managementResponsibilities": [
+          {
+            "description": "Chief Executive Officer",
+            "mrcCode": "A1A7"
+          }
+        ]
+      }
+    ],
+    "currentPrincipals": [
+      {
+        "givenName": "LAWRENCE",
+        "familyName": "ELLISON",
+        "fullName": "LAWRENCE J ELLISON",
+        "namePrefix": "None",
+        "nameSuffix": "None",
+        "gender": "None",
+        "jobTitles": [
+          {
+            "title": "Chairman of the Board"
+          },
+          {
+            "title": "Chief Technology Officer"
+          }
+        ],
+        "managementResponsibilities": [
+          {
+            "description": "Chairman of the Board",
+            "mrcCode": "A1A4"
+          },
+          {
+            "description": "Chief Technology Officer",
+            "mrcCode": "C2A2"
+          }
+        ]
+      },
+      {
+        "givenName": "JEFFREY",
+        "familyName": "HENLEY",
+        "fullName": "JEFFREY O HENLEY",
+        "namePrefix": "None",
+        "nameSuffix": "None",
+        "gender": "None",
+        "jobTitles": [
+          {
+            "title": "Vice Chairman of the Board"
+          }
+        ],
+        "managementResponsibilities": [
+          {
+            "description": "Vice-Chairman of the Board",
+            "mrcCode": "A1CB"
+          }
+        ]
+      },
+      {
+        "givenName": "WILLIAM",
+        "familyName": "WEST",
+        "fullName": "WILLIAM COREY WEST",
+        "namePrefix": "None",
+        "nameSuffix": "None",
+        "gender": "None",
+        "jobTitles": [
+          {
+            "title": "Executive Vice President"
+          },
+          {
+            "title": "Officer"
+          }
+        ],
+        "managementResponsibilities": [
+          {
+            "description": "Executive Vice-President",
+            "mrcCode": "A5D4"
+          },
+          {
+            "description": "Officer",
+            "mrcCode": "A199"
+          }
+        ]
+      },
+      {
+        "givenName": "DORIAN",
+        "familyName": "DALEY",
+        "fullName": "DORIAN E DALEY",
+        "namePrefix": "None",
+        "nameSuffix": "None",
+        "gender": "None",
+        "jobTitles": [
+          {
+            "title": "Executive Vice President"
+          },
+          {
+            "title": "General Counsel"
+          }
+        ],
+        "managementResponsibilities": [
+          {
+            "description": "Executive Vice-President",
+            "mrcCode": "A5D4"
+          },
+          {
+            "description": "General Counsel",
+            "mrcCode": "XDX1"
+          }
+        ]
+      },
+      {
+        "givenName": "EDWARD",
+        "familyName": "SCREVEN",
+        "fullName": "EDWARD SCREVEN",
+        "namePrefix": "None",
+        "nameSuffix": "None",
+        "gender": "None",
+        "jobTitles": [
+          {
+            "title": "Executive Vice President"
+          }
+        ],
+        "managementResponsibilities": [
+          {
+            "description": "Executive Vice-President",
+            "mrcCode": "A5D4"
+          }
+        ]
+      }
+    ],
+    "socioEconomicInformation": {},
+    "isStandalone": false,
+    "corporateLinkage": {
+      "familytreeRolesPlayed": [
+        {
+          "description": "Global Ultimate",
+          "dnbCode": 12775
+        },
+        {
+          "description": "Domestic Ultimate",
+          "dnbCode": 12774
+        },
+        {
+          "description": "Parent/Headquarters",
+          "dnbCode": 9141
+        }
+      ],
+      "hierarchyLevel": 1,
+      "globalUltimateFamilyTreeMembersCount": 1035,
+      "globalUltimate": {
+        "duns": "144709193",
+        "primaryName": "Oracle Corporation",
+        "primaryAddress": {
+          "addressCountry": {
+            "name": "United States",
+            "isoAlpha2Code": "US",
+            "fipsCode": "US"
+          },
+          "continentalRegion": {
+            "name": "North America"
+          },
+          "addressLocality": {
+            "name": "Austin"
+          },
+          "addressRegion": {
+            "name": "Texas",
+            "abbreviatedName": "TX"
+          },
+          "addressCounty": {},
+          "postalCode": "78741-1400",
+          "streetAddress": {
+            "line1": "2300 Oracle Way",
+            "line2": "None"
+          }
+        }
+      },
+      "domesticUltimate": {
+        "duns": "144709193",
+        "primaryName": "Oracle Corporation",
+        "primaryAddress": {
+          "addressCountry": {
+            "name": "United States",
+            "isoAlpha2Code": "US",
+            "fipsCode": "US"
+          },
+          "continentalRegion": {
+            "name": "North America"
+          },
+          "addressLocality": {
+            "name": "Austin"
+          },
+          "addressRegion": {
+            "name": "Texas",
+            "abbreviatedName": "TX"
+          },
+          "addressCounty": {},
+          "postalCode": "78741-1400",
+          "streetAddress": {
+            "line1": "2300 Oracle Way",
+            "line2": "None"
+          }
+        }
+      },
+      "parent": {},
+      "headQuarter": {}
+    }
+  }
+}

--- a/dnb_direct_plus/tests/test_mapping.py
+++ b/dnb_direct_plus/tests/test_mapping.py
@@ -1,3 +1,4 @@
+from calendar import c
 import json
 
 import pytest
@@ -8,6 +9,7 @@ from ..constants import (
 
 from ..mapping import (
     extract_address,
+    extract_domain,
     extract_annual_sales,
     extract_company_data,
     extract_employee_numbers,
@@ -1020,6 +1022,14 @@ def test_extract_employee_numbers(input_data, expected):
 ])
 def test_extract_annual_sales(input_data, expected):
     assert extract_annual_sales(input_data) == expected
+
+
+def test_extract_domain_ingest(company_by_duns_v1_api_response_json):
+
+    company_data = json.loads(company_by_duns_v1_api_response_json)
+    extracted_data = extract_domain(company_data)
+
+    assert extracted_data == 'www.oracle.com'
 
 
 def test_company_list_ingest(company_list_api_response_json):

--- a/dnb_direct_plus/tests/test_mapping.py
+++ b/dnb_direct_plus/tests/test_mapping.py
@@ -1,4 +1,3 @@
-from calendar import c
 import json
 
 import pytest


### PR DESCRIPTION
At the current implementation, Dun & Bradstreet info (turnover, employees, website, trading name, address county) is missing when creating a new DH record.