### PR TITLE
Bump Django to 4.2.11

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -85,7 +85,7 @@ cron-descriptor==1.4.3
     #   django-celery-beat
 dj-database-url==0.5.0
     # via -r requirements.txt
-django==4.2.10
+django==4.2.11
     # via
     #   -r requirements.txt
     #   django-celery-beat

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,14 +10,22 @@ amqp==5.0.9
     #   kombu
 argh==0.26.2
     # via watchdog
+asgiref==3.8.1
+    # via
+    #   -r requirements.txt
+    #   django
 async-timeout==4.0.2
     # via
     #   -r requirements.txt
     #   redis
 atomicwrites==1.3.0
     # via pytest
-attrs==19.1.0
-    # via pytest
+attrs==23.2.0
+    # via
+    #   -r requirements.txt
+    #   jsonschema
+    #   pytest
+    #   referencing
 backoff==1.10.0
     # via -r requirements.txt
 billiard==3.6.4.0
@@ -67,36 +75,31 @@ click-repl==0.2.0
     #   celery
 codecov==2.1.13
     # via -r requirements-dev.in
-coreapi==2.3.3
-    # via
-    #   -r requirements.txt
-    #   drf-yasg
-coreschema==0.0.4
-    # via
-    #   -r requirements.txt
-    #   coreapi
-    #   drf-yasg
 coverage==4.5.1
     # via
     #   codecov
     #   pytest-cov
+cron-descriptor==1.4.3
+    # via
+    #   -r requirements.txt
+    #   django-celery-beat
 dj-database-url==0.5.0
     # via -r requirements.txt
 django==4.2.10
     # via
     #   -r requirements.txt
     #   django-celery-beat
+    #   django-extensions
     #   django-staff-sso-client
-    #   django-timezone-field
     #   djangorestframework
-    #   drf-yasg
+    #   drf-spectacular
 django-celery-beat==2.6.0
     # via -r requirements.txt
 django-celery-results==2.4.0
     # via -r requirements.txt
 django-environ==0.4.5
     # via -r requirements.txt
-django-extensions>=3.O.O
+django-extensions==3.2.3
     # via -r requirements-dev.in
 django-prometheus==2.3.1
     # via -r requirements.txt
@@ -110,7 +113,7 @@ djangorestframework==3.14.0
     # via
     #   -r requirements-dev.in
     #   -r requirements.txt
-    #   drf-yasg
+    #   drf-spectacular
 docopt==0.6.2
     # via
     #   -r requirements.txt
@@ -118,6 +121,9 @@ docopt==0.6.2
 docutils==0.14
     # via -r requirements-dev.in
 drf-spectacular==0.27.1
+    # via
+    #   -r requirements-dev.in
+    #   -r requirements.txt
 elastic-apm==6.2.0
     # via -r requirements.txt
 entrypoints==0.3
@@ -155,28 +161,24 @@ importlib-metadata==6.8.0
 inflection==0.5.1
     # via
     #   -r requirements.txt
-    #   drf-yasg
-itypes==1.2.0
-    # via
-    #   -r requirements.txt
-    #   coreapi
-jinja2==3.1.3
-    # via
-    #   -r requirements.txt
-    #   coreschema
+    #   drf-spectacular
 jmespath==0.10.0
     # via
     #   -r requirements.txt
     #   boto3
     #   botocore
+jsonschema==4.21.1
+    # via
+    #   -r requirements.txt
+    #   drf-spectacular
+jsonschema-specifications==2023.12.1
+    # via
+    #   -r requirements.txt
+    #   jsonschema
 kombu==5.2.3
     # via
     #   -r requirements.txt
     #   celery
-markupsafe==2.0.1
-    # via
-    #   -r requirements.txt
-    #   jinja2
 mccabe==0.6.1
     # via flake8
 more-itertools==7.0.0
@@ -188,10 +190,7 @@ oauthlib==3.2.2
     #   -r requirements.txt
     #   requests-oauthlib
 packaging==21.0
-    # via
-    #   -r requirements.txt
-    #   drf-yasg
-    #   pytest
+    # via pytest
 pathtools==0.1.2
     # via watchdog
 pluggy==0.13.1
@@ -221,9 +220,7 @@ pyjwt==2.4.0
     #   -r requirements.txt
     #   notifications-python-client
 pyparsing==2.4.7
-    # via
-    #   -r requirements.txt
-    #   packaging
+    # via packaging
 pytest==4.6.3
     # via
     #   -r requirements-dev.in
@@ -254,19 +251,24 @@ pytz==2022.1
     # via
     #   -r requirements.txt
     #   celery
-    #   django
     #   django-timezone-field
+    #   djangorestframework
 pyyaml==6.0.1
     # via
     #   -r requirements.txt
+    #   drf-spectacular
     #   watchdog
 redis==4.5.4
     # via -r requirements.txt
+referencing==0.34.0
+    # via
+    #   -r requirements.txt
+    #   jsonschema
+    #   jsonschema-specifications
 requests==2.31.0
     # via
     #   -r requirements.txt
     #   codecov
-    #   coreapi
     #   notifications-python-client
     #   requests-mock
     #   requests-oauthlib
@@ -276,10 +278,11 @@ requests-oauthlib==1.3.0
     # via
     #   -r requirements.txt
     #   django-staff-sso-client
-ruamel-yaml==0.17.22
+rpds-py==0.18.0
     # via
     #   -r requirements.txt
-    #   drf-yasg
+    #   jsonschema
+    #   referencing
 s3transfer==0.4.2
     # via
     #   -r requirements.txt
@@ -290,7 +293,6 @@ six==1.16.0
     # via
     #   -r requirements.txt
     #   click-repl
-    #   django-extensions
     #   faker
     #   flake8-print
     #   freezegun
@@ -305,11 +307,14 @@ sqlparse==0.4.4
     #   django
 text-unidecode==1.3
     # via faker
+tzdata==2024.1
+    # via
+    #   -r requirements.txt
+    #   django-celery-beat
 uritemplate==3.0.1
     # via
     #   -r requirements.txt
-    #   coreapi
-    #   drf-yasg
+    #   drf-spectacular
 urllib3==1.26.18
     # via
     #   -r requirements.txt

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 django==4.2.10
-djangorestframework==3.11.2
+djangorestframework==3.14.0
 boto3
 dj-database-url
 django-environ

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-django==4.2.10
+django==4.2.11
 djangorestframework==3.14.0
 boto3
 dj-database-url

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,14 @@
 #
 amqp==5.0.9
     # via kombu
+asgiref==3.8.1
+    # via django
 async-timeout==4.0.2
     # via redis
+attrs==23.2.0
+    # via
+    #   jsonschema
+    #   referencing
 backoff==1.10.0
     # via -r requirements.in
 billiard==3.6.4.0
@@ -43,12 +49,8 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.2.0
     # via celery
-coreapi==2.3.3
-    # via drf-yasg
-coreschema==0.0.4
-    # via
-    #   coreapi
-    #   drf-yasg
+cron-descriptor==1.4.3
+    # via django-celery-beat
 dj-database-url==0.5.0
     # via -r requirements.in
 django==4.2.10
@@ -56,9 +58,8 @@ django==4.2.10
     #   -r requirements.in
     #   django-celery-beat
     #   django-staff-sso-client
-    #   django-timezone-field
     #   djangorestframework
-    #   drf-yasg
+    #   drf-spectacular
 django-celery-beat==2.6.0
     # via -r requirements.in
 django-celery-results==2.4.0
@@ -71,13 +72,14 @@ django-staff-sso-client==4.2.2
     # via -r requirements.in
 django-timezone-field==5.0
     # via django-celery-beat
-djangorestframework==3.11.2
+djangorestframework==3.14.0
     # via
     #   -r requirements.in
-    #   drf-yasg
+    #   drf-spectacular
 docopt==0.6.2
     # via notifications-python-client
 drf-spectacular==0.27.1
+    # via -r requirements.in
 elastic-apm==6.2.0
     # via -r requirements.in
 gunicorn==20.1.0
@@ -85,25 +87,21 @@ gunicorn==20.1.0
 idna==2.10
     # via requests
 inflection==0.5.1
-    # via drf-yasg
-itypes==1.2.0
-    # via coreapi
-jinja2==3.1.3
-    # via coreschema
+    # via drf-spectacular
 jmespath==0.10.0
     # via
     #   boto3
     #   botocore
+jsonschema==4.21.1
+    # via drf-spectacular
+jsonschema-specifications==2023.12.1
+    # via jsonschema
 kombu==5.2.3
     # via celery
-markupsafe==2.0.1
-    # via jinja2
 notifications-python-client==6.2.1
     # via -r requirements.in
 oauthlib==3.2.2
     # via requests-oauthlib
-packaging==21.0
-    # via drf-yasg
 prometheus-client==0.11.0
     # via django-prometheus
 prompt-toolkit==3.0.18
@@ -112,8 +110,6 @@ psycopg2==2.8.6
     # via -r requirements.in
 pyjwt==2.4.0
     # via notifications-python-client
-pyparsing==2.4.7
-    # via packaging
 python-crontab==2.5.1
     # via django-celery-beat
 python-dateutil==2.8.1
@@ -123,22 +119,29 @@ python-dateutil==2.8.1
 pytz==2022.1
     # via
     #   celery
-    #   django
     #   django-timezone-field
+    #   djangorestframework
 pyyaml==6.0.1
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   drf-spectacular
 redis==4.5.4
     # via -r requirements.in
+referencing==0.34.0
+    # via
+    #   jsonschema
+    #   jsonschema-specifications
 requests==2.31.0
     # via
     #   -r requirements.in
-    #   coreapi
     #   notifications-python-client
     #   requests-oauthlib
 requests-oauthlib==1.3.0
     # via django-staff-sso-client
-ruamel-yaml==0.17.22
-    # via drf-yasg
+rpds-py==0.18.0
+    # via
+    #   jsonschema
+    #   referencing
 s3transfer==0.4.2
     # via boto3
 sentry-sdk==1.14.0
@@ -153,10 +156,10 @@ sqlparse==0.4.4
     # via
     #   -r requirements.in
     #   django
+tzdata==2024.1
+    # via django-celery-beat
 uritemplate==3.0.1
-    # via
-    #   coreapi
-    #   drf-yasg
+    # via drf-spectacular
 urllib3==1.26.18
     # via
     #   -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ cron-descriptor==1.4.3
     # via django-celery-beat
 dj-database-url==0.5.0
     # via -r requirements.in
-django==4.2.10
+django==4.2.11
     # via
     #   -r requirements.in
     #   django-celery-beat


### PR DESCRIPTION
Bump Django to 4.2.11 to fix a vulnerability. Dependabot was also reporting a dependency conflict as we are using multiple DRF versions - I have sorted this as well.