### PR TITLE
initial build configuration

### DIFF
--- a/.copilot/config.yml
+++ b/.copilot/config.yml
@@ -1,0 +1,4 @@
+repository: dnb
+builder:
+  name: paketobuildpacks/builder-jammy-full
+  version: 0.3.339


### PR DESCRIPTION
Adds the initial build configuration needed to make container images for deployment to DBT Platform.