### PR TITLE
Setup Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: pip
+  directory: "/"
+  schedule:
+    interval: weekly
+    time: "00:00"
+    timezone: Europe/London
+  open-pull-requests-limit: 10
+  rebase-strategy: disabled


### PR DESCRIPTION
As Data Hub are now responsible for this service Dependabot is being introduced. This will be included in the Dependabot rota going forward.