### PR TITLE
Compatibility changes required to bump Django to 5.0.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: circleci/python:3.9.7
+      - image: cimg/python:3.10.14
       - image: postgres:16
         environment:
           POSTGRES_DB: dnb-service
@@ -25,9 +25,9 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "requirements-dev.txt" }}
+            - v2-dependencies-{{ checksum "requirements-dev.txt" }}
             # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
+            - v2-dependencies-
 
       - run:
           name: install dependencies
@@ -39,7 +39,7 @@ jobs:
       - save_cache:
           paths:
             - ./venv
-          key: v1-dependencies-{{ checksum "requirements-dev.txt" }}
+          key: v2-dependencies-{{ checksum "requirements-dev.txt" }}
 
       - run:
           name: run tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.7
+FROM python:3.10.14
 
 RUN apt-get update && apt-get install -y wget
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -132,7 +132,6 @@ TIME_ZONE = 'UTC'
 
 USE_I18N = True
 
-USE_L10N = True
 
 USE_TZ = True
 

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -28,7 +28,7 @@ def _get_client_ip(request):
     client_ip_index = getattr(settings, 'IP_SAFELIST_XFF_INDEX', -2)
 
     try:
-        return request.META['HTTP_X_FORWARDED_FOR'].split(',')[client_ip_index].strip()
+        return request.headers['x-forwarded-for'].split(',')[client_ip_index].strip()
     except (IndexError, KeyError):
         logger.warning(
             'X-Forwarded-For header is missing or does not '

--- a/docker-compose.data-hub-api.yml
+++ b/docker-compose.data-hub-api.yml
@@ -1,4 +1,3 @@
-version: "2"
 services:
   api-dnb:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "2"
 services:
   api:
     build:

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -11,7 +11,7 @@ flake8
 # Testing utilities
 freezegun
 pytest-cov
-pytest-django
+pytest-django==4.8.0
 pytest-env
 pytest-mock
 pytest==8.3.2

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -14,7 +14,7 @@ pytest-cov
 pytest-django
 pytest-env
 pytest-mock
-pytest
+pytest==8.3.2
 requests-mock
 factory_boy
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,13 +18,10 @@ async-timeout==4.0.3
     # via
     #   -r requirements.txt
     #   redis
-atomicwrites==1.3.0
-    # via pytest
 attrs==23.2.0
     # via
     #   -r requirements.txt
     #   jsonschema
-    #   pytest
     #   referencing
 backoff==1.10.0
     # via
@@ -156,6 +153,8 @@ ecs-logging==2.2.0
     #   elastic-apm
 elastic-apm==6.23.0
     # via -r requirements.txt
+exceptiongroup==1.2.2
+    # via pytest
 factory-boy==3.3.0
     # via -r requirements-dev.in
 faker==2.0.4
@@ -205,11 +204,12 @@ importlib-metadata==6.11.0
     # via
     #   -r requirements.txt
     #   opentelemetry-api
-    #   pytest
 inflection==0.5.1
     # via
     #   -r requirements.txt
     #   drf-spectacular
+iniconfig==2.0.0
+    # via pytest
 jmespath==0.10.0
     # via
     #   -r requirements.txt
@@ -229,8 +229,6 @@ kombu==5.3.7
     #   celery
 mccabe==0.7.0
     # via flake8
-more-itertools==7.0.0
-    # via pytest
 nodeenv==1.8.0
     # via
     #   -r requirements.txt
@@ -322,7 +320,7 @@ platformdirs==4.2.0
     # via
     #   -r requirements.txt
     #   virtualenv
-pluggy==0.13.1
+pluggy==1.5.0
     # via pytest
 pre-commit==3.7.0
     # via
@@ -343,8 +341,6 @@ protobuf==4.25.3
     #   opentelemetry-proto
 psycopg2==2.9.9
     # via -r requirements.txt
-py==1.10.0
-    # via pytest
 pycodestyle==2.12.0
     # via
     #   flake8
@@ -357,7 +353,7 @@ pyjwt==2.4.0
     # via
     #   -r requirements.txt
     #   notifications-python-client
-pytest==4.6.3
+pytest==8.3.2
     # via
     #   -r requirements-dev.in
     #   pytest-cov
@@ -432,7 +428,6 @@ six==1.16.0
     #   -r requirements.txt
     #   click-repl
     #   faker
-    #   pytest
     #   python-dateutil
     #   requests-mock
 smart-open==7.0.4
@@ -444,7 +439,9 @@ sqlparse==0.5.0
 text-unidecode==1.3
     # via faker
 tomli==2.0.1
-    # via coverage
+    # via
+    #   coverage
+    #   pytest
 typing-extensions==4.11.0
     # via
     #   -r requirements.txt
@@ -483,7 +480,6 @@ wcwidth==0.2.5
     # via
     #   -r requirements.txt
     #   prompt-toolkit
-    #   pytest
 whitenoise==6.7.0
     # via -r requirements.txt
 wrapt==1.16.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -362,7 +362,7 @@ pytest==8.3.2
     #   pytest-mock
 pytest-cov==5.0.0
     # via -r requirements-dev.in
-pytest-django==3.5.0
+pytest-django==4.8.0
     # via -r requirements-dev.in
 pytest-env==0.6.2
     # via -r requirements-dev.in

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.9.x
+python-3.10.x


### PR DESCRIPTION
This PR originally bumped Django from `4.2.14` to `5.0.8`. However, after some discussion it was decided to stay on `4.2.x` until `5.2.x` is released. Instead of letting this PR go stale, we decided to merge in any compatible changes (with `4.2.x`) now in an attempt to reduce work in the future.

> [!IMPORTANT]
> This PR does NOT bump Django to `5.0.x`

The main changes include:

- Rewrite imports of `django.utils.timezone.utc` to use `datetime.timezone.utc` as Django alias has been deprecated
- Remove deprecated `USE_L10N` setting
- Rewrite use of `request.META` to read HTTP headers to instead use `request.headers`
- Using Python 3.10.14 in Docker images and CircleCI

I also had to:
- Bump pytest to 8.3.2 to resolve TypeError when running in Python 3.10 envs
- Bump pytest-django to 4.8.0 to resolve AtrributeError: 'SubRequest' object has no attribute 'funcargnames'

Lastly, I removed the deprecated version key in docker-compose files as Docker kept warning me about these.
