### PR TITLE
Delete manifest file

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,4 +1,0 @@
----
-applications:
-  - name: external-company-service
-    stack: cflinuxfs4


### PR DESCRIPTION
Now that we've migrated off PaaS we don't need to keep the manifest file anymore.