### PR TITLE
Revert "Bump notifications-python-client from 6.2.1 to 10.0.0"

### DIFF
--- a/company/tests/test_tasks.py
+++ b/company/tests/test_tasks.py
@@ -105,12 +105,7 @@ class TestSendPendingChangeRequests:
                     template_id=TEMPLATE_IDS['change-request'],
                     personalisation={
                         'batch_identifier': 'Monday 25 November 2019',
-                        'link_to_file': {
-                            'confirm_email_before_download': None,
-                            'file': expected_batch_1_encoded,
-                            'filename': None,
-                            'retention_period': None,
-                        },
+                        'link_to_file': {'file': expected_batch_1_encoded, 'is_csv': True},
                     },
                 ),
                 mock.call(
@@ -118,12 +113,7 @@ class TestSendPendingChangeRequests:
                     template_id=TEMPLATE_IDS['change-request'],
                     personalisation={
                         'batch_identifier': 'Monday 25 November 2019 Part 2',
-                        'link_to_file': {
-                            'confirm_email_before_download': None,
-                            'file': expected_batch_2_encoded,
-                            'filename': None,
-                            'retention_period': None,
-                        },
+                        'link_to_file': {'file': expected_batch_2_encoded, 'is_csv': True},
                     },
                 ),
             ],
@@ -238,12 +228,7 @@ class TestSendPendingInvestigationRequests:
             template_id=TEMPLATE_IDS['investigation-request'],
             personalisation={
                 'batch_identifier': 'Monday 25 November 2019',
-                'link_to_file': {
-                    'confirm_email_before_download': None,
-                    'file': b64encode(csv_bytes).decode('ascii'),
-                    'filename': None,
-                    'retention_period': None,
-                },
+                'link_to_file': {'file': b64encode(csv_bytes).decode('ascii'), 'is_csv': True},
             },
         )
 

--- a/company/tests/test_utils.py
+++ b/company/tests/test_utils.py
@@ -114,6 +114,7 @@ class TestSendChangeRequestBatch:
                         'batch_identifier': 'Batch 1',
                         'link_to_file': mocked_generate_change_request_csv.return_value,
                     },
+                    is_csv=True,
                 ),
                 mock.call(
                     'bar@example.net',
@@ -122,6 +123,7 @@ class TestSendChangeRequestBatch:
                         'batch_identifier': 'Batch 1',
                         'link_to_file': mocked_generate_change_request_csv.return_value,
                     },
+                    is_csv=True,
                 ),
             ]
         )
@@ -256,6 +258,7 @@ class TestSendInvestigationRequestBatch:
                 'batch_identifier': 'Batch 1',
                 'link_to_file': mock.ANY,
             },
+            is_csv=True,
         )
         assert mock_notify.call_count == 2
         assert mock_notify.call_args[0][2]['link_to_file'].getvalue() == csv_bytes

--- a/company/utils.py
+++ b/company/utils.py
@@ -84,7 +84,7 @@ def send_change_request_batch(change_requests, batch_identifier):
         'link_to_file': generate_change_request_csv(change_requests),
     }
     for email_address in settings.CHANGE_REQUESTS_RECIPIENTS:
-        notify_by_email(email_address, TEMPLATE_IDS['change-request'], context)
+        notify_by_email(email_address, TEMPLATE_IDS['change-request'], context, is_csv=True)
     submitted_on = now()
     for change_request in change_requests:
         change_request.mark_as_submitted(submitted_on)
@@ -151,6 +151,7 @@ def send_investigation_request_batch(investigation_requests, batch_identifier):
             email_address,
             TEMPLATE_IDS['investigation-request'],
             context,
+            is_csv=True,
         )
 
     submitted_on = now()

--- a/core/notify.py
+++ b/core/notify.py
@@ -15,7 +15,7 @@ TEMPLATE_IDS = {
 }
 
 
-def notify_by_email(email_address, template_identifier, context):
+def notify_by_email(email_address, template_identifier, context, is_csv=False):
     """
     Notify an email address, using a GOVUK notify template and some template
     context.
@@ -24,7 +24,7 @@ def notify_by_email(email_address, template_identifier, context):
     # to an uploadable string
     for key, value in context.items():
         if isinstance(value, io.IOBase):
-            context[key] = prepare_upload(value)
+            context[key] = prepare_upload(value, is_csv=is_csv)
     response = notifications_client.send_email_notification(
         email_address=email_address,
         template_id=template_identifier,

--- a/core/tests/test_notify.py
+++ b/core/tests/test_notify.py
@@ -35,12 +35,7 @@ def test_notify_by_email_with_file(monkeypatch):
     }
     expected_personalisation = {
         **context,
-        'file': {
-            'confirm_email_before_download': None,
-            'file': 'Zm9vIGJhciBiYXo=',
-            'filename': None,
-            'retention_period': None,
-        },
+        'file': {'file': 'Zm9vIGJhciBiYXo=', 'is_csv': False},
     }
     notify_by_email(email_address, template_id, context)
     notifications_client_mock.send_email_notification.assert_called_with(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -231,7 +231,7 @@ nodeenv==1.8.0
     # via
     #   -r requirements.txt
     #   pre-commit
-notifications-python-client==10.0.0
+notifications-python-client==6.2.1
     # via -r requirements.txt
 oauthlib==3.2.2
     # via

--- a/requirements.in
+++ b/requirements.in
@@ -16,7 +16,7 @@ sentry-sdk==2.20.0
 backoff
 django-prometheus==2.3.1
 smart-open
-notifications-python-client==10.0.0
+notifications-python-client==6.2.1
 elastic-apm
 django-log-formatter-asim==0.0.6
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -135,7 +135,7 @@ kombu==5.3.7
     # via celery
 nodeenv==1.8.0
     # via pre-commit
-notifications-python-client==10.0.0
+notifications-python-client==6.2.1
     # via -r requirements.in
 oauthlib==3.2.2
     # via requests-oauthlib


### PR DESCRIPTION
Reverts uktrade/dnb-service#190

DNB have been recieving investigation files as TXT rather than CSV, which is causing them problems. The upgrade to 10.0.0 changed how the CSV extension is specified so will roll this back for now so they don't have problems while we look into this again.