### PR TITLE
Dependabot (2025-02-06)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     timezone: Europe/London
   open-pull-requests-limit: 10
   rebase-strategy: disabled
+  ignore:
+      - dependency-name: notifications-python-client
+        versions:
+        - ">= 6.2.1"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -31,9 +31,9 @@ billiard==4.2.0
     # via
     #   -r requirements.txt
     #   celery
-boto3==1.36.6
+boto3==1.36.11
     # via -r requirements.txt
-botocore==1.36.6
+botocore==1.36.11
     # via
     #   -r requirements.txt
     #   boto3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -44,7 +44,7 @@ celery==5.4.0
     #   dbt-copilot-python
     #   django-celery-beat
     #   django-celery-results
-certifi==2024.12.14
+certifi==2025.1.31
     # via
     #   -r requirements.txt
     #   elastic-apm

--- a/requirements.in
+++ b/requirements.in
@@ -27,4 +27,4 @@ urllib3>=1.26.5
 drf-spectacular==0.28.0
 
 sqlparse==0.5.3
-certifi==2024.12.14
+certifi==2025.1.31

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ celery==5.4.0
     #   dbt-copilot-python
     #   django-celery-beat
     #   django-celery-results
-certifi==2024.12.14
+certifi==2025.1.31
     # via
     #   -r requirements.in
     #   elastic-apm

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,9 +22,9 @@ backoff==2.2.1
     #   opentelemetry-exporter-otlp-proto-http
 billiard==4.2.0
     # via celery
-boto3==1.36.6
+boto3==1.36.11
     # via -r requirements.in
-botocore==1.36.6
+botocore==1.36.11
     # via
     #   boto3
     #   s3transfer


### PR DESCRIPTION
This week's Dependabot updates. The `notifications-python-client` dependency has been added to the ignore list as upgrading it causes issues for DNB.