### PR TITLE
Downgrade Python to latest supported version 3.12.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,9 @@ jobs:
 
       - restore_cache:
           keys:
-            - dependencies-{{ checksum "requirements-dev.txt" }}
+            - v2-dependencies-{{ checksum "requirements-dev.txt" }}
             # fallback to using the latest cache if no exact match is found
-            - dependencies-
+            - v2-dependencies-
 
       - run:
           name: Create and activate virtual environment
@@ -42,7 +42,7 @@ jobs:
       - save_cache:
           paths:
             - ./venv
-          key: dependencies-{{ checksum "requirements-dev.txt" }}
+          key: v2-dependencies-{{ checksum "requirements-dev.txt" }}
 
       - run:
           name: Run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,9 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "requirements-dev.txt" }}
+            - dependencies-{{ checksum "requirements-dev.txt" }}
             # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
+            - dependencies-
 
       - run:
           name: Create and activate virtual environment
@@ -42,7 +42,7 @@ jobs:
       - save_cache:
           paths:
             - ./venv
-          key: v1-dependencies-{{ checksum "requirements-dev.txt" }}
+          key: dependencies-{{ checksum "requirements-dev.txt" }}
 
       - run:
           name: Run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: cimg/python:3.12.10
+      - image: cimg/python:3.12.8
       - image: postgres:16
         environment:
           POSTGRES_DB: dnb-service

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.10
+FROM python:3.12.8
 
 RUN apt-get update && apt-get install -y wget
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Dependencies
 
-Python 3.12.10
+Python 3.12.8
 Django 5.2.1  
 Postgres 16  
 
@@ -14,7 +14,7 @@ Postgres 16
 
 2. Set up and activate a virtual env  
    ````
-   python3.12.10 -m venv env
+   python3.12.8 -m venv env
    source env/bin/activate
    ````
 


### PR DESCRIPTION
Following the merging of #384, the build stage failed due to Python 3.12.10 being unsupported, despite being listed as otherwise.

This PR downgrades Python to the latest supported version 3.12.8.

It also renames the dependency cache to essentially "burst" it and force the creation and use of a new one. Despite attempting to delete the Docker cache layer via the UI, the workflow still "found a cache from build 1197 at dependencies-" and failed again.