### PR TITLE
Improve handling of expected 404

### DIFF
--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -339,8 +339,20 @@ class TestCompanyHierarchySearchView:
 
 
     def test_404_returns_empty_data(self, auth_client, mocker):
+        mock_response = mocker.Mock()
+        mock_response.status_code = 404
+        mock_response.json.return_value = {
+            "error": {
+                "errorCode": "Code",
+                "errorMessage": "Message",
+            }
+        }
+
+        http_error = HTTPError()
+        http_error.response = mock_response
+
         mock_api_request = mocker.patch('dnb_direct_plus.api.api_request')
-        mock_api_request.side_effect = HTTPError(response=mocker.Mock(status_code=404))
+        mock_api_request.side_effect = http_error
 
         response = auth_client.post(
             reverse('api:company-hierarchy-search'),

--- a/dnb_direct_plus/api.py
+++ b/dnb_direct_plus/api.py
@@ -168,17 +168,31 @@ def company_hierarchy_list_initial_request(query):
 def company_hierarchy_api_request(url):
     """
     Request logic for company_hierarchy_list_search()
+
+    Returns:
+        dict: Company hierarchy data if found, empty dict if not
+
+    Raises:
+        HTTPError: For non-404 HTTP errors
     """
     try:
         response = api_request("GET", url)
-    except HTTPError as ex:
-        logger.exception("HTTP error occurred")
-        if ex.response.status_code == 404:
-            return {}
-        else:
-            raise
-    else:
         return response.json()
+
+    except HTTPError as ex:
+        status_code = ex.response.status_code
+        error_json = ex.response.json()['error']
+
+        if status_code == 404:
+            logger.info(
+                f'Company hierarchy not found - {url} - '
+                f'D&B error {error_json['errorCode']}: {error_json['errorMessage']}'
+            )
+            return {}
+
+        else:
+            logger.error(f'D&B error {error_json['errorCode']}: {error_json['errorMessage']}')
+            raise
 
 
 def company_hierarchy_list_search(query):

--- a/dnb_direct_plus/tests/test_api.py
+++ b/dnb_direct_plus/tests/test_api.py
@@ -7,7 +7,8 @@ from requests.exceptions import HTTPError
 from company.constants import MonitoringStatusChoices
 from company.models import Company
 
-from ..api import (
+from dnb_direct_plus.api import (
+    company_hierarchy_api_request,
     company_hierarchy_count,
     company_hierarchy_list_search,
     company_list_search,
@@ -161,12 +162,14 @@ def test_company_list_search_v2_detail_query_company_data_is_saved(
     assert company.duns_number == output["results"][0]["duns_number"]
     assert company.monitoring_status == MonitoringStatusChoices.pending.name
 
+
 class ApiHierarchyRequestJsonFake:
     def __init__(self, json_data):
         self.json_data = json_data
 
     def json(self):
         return self.json_data
+
 
 @pytest.mark.django_db
 def test_company_hierarchy_single_list_search(
@@ -193,8 +196,6 @@ def test_company_hierarchy_paginated_list_search(
     company_hierarchy_first_page_api_response_json,
     company_hierarchy_last_page_api_response_json,
 ):
-    
-
     company_hierarchy_first_page_data = json.loads(
         company_hierarchy_first_page_api_response_json
     )
@@ -215,12 +216,114 @@ def test_company_hierarchy_paginated_list_search(
     assert output["branches_excluded_members_count"] == 1
     assert output["family_tree_members"][0]["duns"] == "444444444"
     assert output["family_tree_members"][1]["duns"] == "555555555"
-   
-    
-def test_company_hierarchy_count_returns_value(
-    mocker
-):
+
+
+def test_company_hierarchy_count_returns_value(mocker):
     mock_api_request = mocker.patch("dnb_direct_plus.api.api_request")
-    mock_api_request.side_effect = ApiHierarchyRequestJsonFake(json_data={'globalUltimateFamilyTreeMembersCount' : 15}),
+    mock_api_request.side_effect = (
+        ApiHierarchyRequestJsonFake(
+            json_data={"globalUltimateFamilyTreeMembersCount": 15}
+        ),
+    )
     count = company_hierarchy_count({"duns_number": "111111111"})
     assert count == 15
+
+
+class MockHTTPErrorResponse:
+    """Mock response object for HTTPError testing."""
+
+    def __init__(self, status_code, response_json):
+        self.status_code = status_code
+        self.response_json = response_json
+
+    def json(self):
+        return self.response_json
+
+
+def test_company_hierarchy_api_request_success_no_logging(mocker, caplog):
+    """Test that successful requests don't generate any log entries."""
+    expected_data = {
+        "globalUltimateFamilyTreeMembersCount": 10,
+        "familyTreeMembers": [],
+    }
+    mock_api_request = mocker.patch("dnb_direct_plus.api.api_request")
+    mock_api_request.side_effect = [ApiHierarchyRequestJsonFake(expected_data)]
+
+    test_url = "v1/familyTree/"
+
+    with caplog.at_level("INFO"):
+        result = company_hierarchy_api_request(test_url)
+
+    assert result == expected_data
+    mock_api_request.assert_called_once_with("GET", test_url)
+
+    assert len(caplog.records) == 0
+
+
+def test_company_hierarchy_api_request_404_logging(mocker, caplog):
+    """Test that 404 errors are not raised and logged at INFO level with D&B error details."""
+    error_code = "000404"
+    error_message = "Unable to find requested company"
+    mock_response = MockHTTPErrorResponse(
+        status_code=404,
+        response_json={
+            "error": {
+                "errorCode": error_code,
+                "errorMessage": error_message,
+            }
+        },
+    )
+    http_error = HTTPError()
+    http_error.response = mock_response
+
+    mock_api_request = mocker.patch("dnb_direct_plus.api.api_request")
+    mock_api_request.side_effect = http_error
+
+    test_url = "v1/familyTree/"
+
+    with caplog.at_level("INFO"):
+        result = company_hierarchy_api_request(test_url)
+
+    assert result == {}
+    mock_api_request.assert_called_once_with("GET", test_url)
+
+    assert len(caplog.records) == 1
+    log_record = caplog.records[0]
+    assert log_record.levelname == "INFO"
+    assert f"Company hierarchy not found - {test_url} - " in log_record.message
+    assert f"D&B error {error_code}: {error_message}" in log_record.message
+
+
+def test_company_hierarchy_api_request_non_404_logging(mocker, caplog):
+    """Test that non-404 errors are raised and logged at ERROR level with D&B error details."""
+    error_code = "000400"
+    error_message = "Bad request"
+    mock_response = MockHTTPErrorResponse(
+        status_code=400,
+        response_json={
+            "error": {
+                "errorCode": error_code,
+                "errorMessage": error_message,
+            }
+        },
+    )
+    http_error = HTTPError()
+    http_error.response = mock_response
+
+    mock_api_request = mocker.patch("dnb_direct_plus.api.api_request")
+    mock_api_request.side_effect = http_error
+
+    test_url = "v1/familyTree/"
+
+    with (
+        pytest.raises(HTTPError),
+        caplog.at_level("ERROR"),
+    ):
+        company_hierarchy_api_request(test_url)
+
+    mock_api_request.assert_called_once_with("GET", test_url)
+
+    assert len(caplog.records) == 1
+    log_record = caplog.records[0]
+    assert log_record.levelname == "ERROR"
+    assert f"D&B error {error_code}: {error_message}" in log_record.message


### PR DESCRIPTION
On occasion, the service logs an exception when a company's hierarchy is not found (missing from Dun and Bradstreet) and their API returns 404. 

As this is expected behaviour (although, we hope not often), this PR downgrades the logging severity to reduce noise in Sentry going forward, and resolve the previously raised issues.